### PR TITLE
Add Radius on AKS Automatic demo

### DIFF
--- a/Radius/Deploy.ps1
+++ b/Radius/Deploy.ps1
@@ -1,0 +1,395 @@
+<#
+.SYNOPSIS
+    Deploys the Radius-on-AKS-Automatic demo end to end.
+
+.DESCRIPTION
+    Automates: resource group creation, Bicep deployment, AKS credential setup,
+    Radius installation via the rad CLI, Azure credential and environment
+    configuration, and deployment of an example Radius application.
+
+    Uses Azure PowerShell cmdlets (Az module) for all Azure operations — these
+    throw terminating errors on failure, so the script halts immediately if
+    anything goes wrong. External tools (kubectl, kubelogin, rad) are checked
+    via exit code after each call.
+
+    Original YAML files are left untouched — generated copies with real values
+    are written to .generated/ and applied from there.
+
+.PARAMETER ResourceGroupName
+    Name of the Azure resource group. Default: rg-radius.
+
+.PARAMETER Location
+    Azure region for all resources. Default: swedencentral.
+
+.PARAMETER SkipInfrastructure
+    Skip Bicep deployment and resource group creation. Useful when re-running
+    only the Kubernetes configuration steps against an existing cluster.
+
+.PARAMETER Cleanup
+    Tears down everything: deletes the Azure resource group (and all resources
+    within it) and removes the local .generated/ folder.
+
+.LINK
+    https://docs.radapp.io/
+
+.EXAMPLE
+    .\Deploy.ps1
+    .\Deploy.ps1 -SkipInfrastructure
+    .\Deploy.ps1 -Cleanup
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ResourceGroupName = 'rg-radius',
+    [string]$Location = 'swedencentral',
+    [switch]$SkipInfrastructure,
+    [switch]$Cleanup
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Script related variables
+$ScriptRoot = $PSScriptRoot
+$GeneratedDir = Join-Path $ScriptRoot '.generated'
+
+# Module related variables
+$RequiredModules = @('Az.Accounts', 'Az.Resources', 'Az.Aks')
+
+########################################################################
+#                     DO NOT EDIT BELOW THIS LINE                      #
+########################################################################
+
+$ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
+
+########################################################################
+#                          Preparations                                #
+########################################################################
+
+#region Preparations
+
+Write-Verbose 'Ensuring required Az modules are installed.'
+
+$Progress = 0
+foreach ($Module in $RequiredModules) {
+    Write-Progress -Activity 'Checking Az modules' -Status $Module -PercentComplete ($Progress / $RequiredModules.Count * 100) -ErrorAction SilentlyContinue
+    if (-not (Get-Module -Name $Module -ListAvailable)) {
+        Write-Verbose "Installing missing module '$Module'..."
+        Install-Module -Name $Module -Scope CurrentUser -Force -AllowClobber
+        Write-Verbose "Module '$Module' installed successfully."
+    }
+    Import-Module $Module -ErrorAction Stop
+    Write-Verbose "Module '$Module' loaded."
+    $Progress++
+}
+Write-Progress -Activity 'Checking Az modules' -Completed -ErrorAction SilentlyContinue
+
+#endregion Preparations
+
+########################################################################
+#                            Cleanup                                   #
+########################################################################
+
+#region Cleanup
+
+if ($Cleanup) {
+    Write-Verbose 'Cleanup mode activated.'
+
+    # Resolve the resource group name from the saved deployment context
+    $ContextFile = Join-Path $GeneratedDir 'deployment-context.json'
+    if (Test-Path $ContextFile) {
+        $SavedContext = Get-Content $ContextFile -Raw | ConvertFrom-Json
+        $ResourceGroupName = $SavedContext.ResourceGroupName
+        Write-Verbose "Loaded resource group name '$ResourceGroupName' from deployment context."
+    }
+    else {
+        Write-Warning "No deployment context found in .generated/ — using parameter value '$ResourceGroupName'. Verify this is the correct resource group before continuing."
+    }
+
+    $ResourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+    if ($ResourceGroup) {
+        Write-Verbose "Deleting resource group '$ResourceGroupName'..."
+        Remove-AzResourceGroup -Name $ResourceGroupName -Force
+        Write-Verbose "Resource group '$ResourceGroupName' deleted."
+    }
+    else {
+        Write-Verbose "Resource group '$ResourceGroupName' not found — nothing to delete."
+    }
+
+    if (Test-Path $GeneratedDir) {
+        Write-Verbose 'Removing .generated/ folder...'
+        Remove-Item $GeneratedDir -Recurse -Force
+        Write-Verbose 'Removed .generated/ folder.'
+    }
+
+    Write-Verbose "Cleanup complete. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
+    return
+}
+
+#endregion Cleanup
+
+function Assert-ExitCode {
+    <#
+    .SYNOPSIS
+        Throws if the last external command returned a non-zero exit code.
+    .PARAMETER Message
+        Error message to include in the thrown exception.
+    .EXAMPLE
+        Assert-ExitCode 'rad install kubernetes failed.'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, HelpMessage = 'Error message to throw on failure.')]
+        [string]$Message
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Message (exit code: $LASTEXITCODE)"
+    }
+}
+
+########################################################################
+#               Part 1 - Deploying infrastructure                      #
+########################################################################
+
+#region Part 1 - Deploying infrastructure
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 1 of 6 — Deploying infrastructure' -PercentComplete 0 -ErrorAction SilentlyContinue
+
+if (-not $SkipInfrastructure) {
+    Write-Verbose 'Deploying infrastructure...'
+
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Creating resource group...' -PercentComplete 0 -ErrorAction SilentlyContinue
+    try {
+        New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Force | Out-Null
+        Write-Verbose "Resource group '$ResourceGroupName' ready."
+    }
+    catch {
+        Write-Verbose "Failed to create resource group '$ResourceGroupName': $($_.Exception.Message)"
+        throw
+    }
+
+    # Save deployment context so cleanup can find the correct resource group
+    if (-not (Test-Path $GeneratedDir)) { New-Item -Path $GeneratedDir -ItemType Directory -Force | Out-Null }
+    @{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
+    Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
+
+    try {
+        $Context = Get-AzContext -ErrorAction Stop
+        if (-not $Context) { throw 'No Azure context found. Run Connect-AzAccount first.' }
+    }
+    catch {
+        Write-Verbose "Failed to get Azure context: $($_.Exception.Message)"
+        throw
+    }
+
+    try {
+        $PrincipalId = (Get-AzADUser -SignedIn -ErrorAction Stop).Id
+        if (-not $PrincipalId) { throw 'Could not determine signed-in user principal ID.' }
+        Write-Verbose "Signed-in user principal ID: $PrincipalId"
+    }
+    catch {
+        Write-Verbose "Failed to get signed-in user principal ID: $($_.Exception.Message)"
+        throw
+    }
+
+    Write-Verbose 'Starting Bicep deployment...'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Bicep deployment in progress — this may take a while...' -PercentComplete 25 -ErrorAction SilentlyContinue
+    try {
+        $DeploymentJob = New-AzResourceGroupDeployment `
+            -Name 'main' `
+            -ResourceGroupName $ResourceGroupName `
+            -TemplateFile "$ScriptRoot/infrastructure/main.bicep" `
+            -clusterAdminPrincipalId $PrincipalId `
+            -AsJob
+
+        while ($DeploymentJob.State -eq 'Running') {
+            Start-Sleep -Seconds 5
+            $MinutesElapsed = [math]::Round(((Get-Date) - $DeploymentJob.PSBeginTime).TotalMinutes, 1)
+            Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status "Bicep deployment in progress — $MinutesElapsed min elapsed" -PercentComplete 50 -ErrorAction SilentlyContinue
+        }
+
+        $DeploymentJob | Receive-Job -Wait -AutoRemoveJob | Out-Null
+        Write-Verbose 'Bicep deployment complete.'
+    }
+    catch {
+        Write-Verbose "Bicep deployment failed: $($_.Exception.Message)"
+        throw
+    }
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Completed -ErrorAction SilentlyContinue
+}
+else {
+    Write-Verbose 'Skipping infrastructure deployment (SkipInfrastructure flag set).'
+}
+
+#endregion Part 1 - Deploying infrastructure
+
+########################################################################
+#             Part 2 - Capturing deployment outputs                    #
+########################################################################
+
+#region Part 2 - Capturing deployment outputs
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 2 of 6 — Capturing deployment outputs' -PercentComplete 17 -ErrorAction SilentlyContinue
+Write-Verbose 'Capturing deployment outputs...'
+
+try {
+    $Deployment = Get-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -Name 'main' -ErrorAction Stop
+    Write-Verbose 'Retrieved deployment outputs.'
+}
+catch {
+    Write-Verbose "Failed to get deployment '$ResourceGroupName/main': $($_.Exception.Message)"
+    throw
+}
+
+$ClusterName = $Deployment.Outputs['clusterName'].Value
+$ClientId    = $Deployment.Outputs['radiusIdentityClientId'].Value
+
+try {
+    $Context        = Get-AzContext -ErrorAction Stop
+    $SubscriptionId = $Context.Subscription.Id
+    $TenantId       = $Context.Tenant.Id
+}
+catch {
+    Write-Verbose "Failed to get Azure context: $($_.Exception.Message)"
+    throw
+}
+
+Write-Verbose "Cluster:        $ClusterName"
+Write-Verbose "Client ID:      $ClientId"
+Write-Verbose "Subscription:   $SubscriptionId"
+Write-Verbose "Tenant:         $TenantId"
+
+#endregion Part 2 - Capturing deployment outputs
+
+########################################################################
+#             Part 3 - Generating Helm values                          #
+########################################################################
+
+#region Part 3 - Generating Helm values
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 3 of 6 — Generating Helm values' -PercentComplete 33 -ErrorAction SilentlyContinue
+Write-Verbose 'Generating Helm values...'
+
+if (Test-Path $GeneratedDir) { Remove-Item $GeneratedDir -Recurse -Force }
+
+Copy-Item -Path (Join-Path $ScriptRoot 'kubernetes') -Destination $GeneratedDir -Recurse
+
+$YamlFiles = Get-ChildItem -Path $GeneratedDir -Recurse -Filter *.yaml
+
+$Progress = 0
+foreach ($File in $YamlFiles) {
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Processing YAML files' -Status $File.Name -PercentComplete ($Progress / $YamlFiles.Count * 100) -ErrorAction SilentlyContinue
+    (Get-Content $File.FullName -Raw) `
+        -replace '<RADIUS_IDENTITY_CLIENT_ID>', $ClientId |
+        Set-Content $File.FullName
+    $Progress++
+}
+Write-Progress -Id 1 -ParentId 0 -Activity 'Processing YAML files' -Completed -ErrorAction SilentlyContinue
+
+Write-Verbose "Generated files in $GeneratedDir"
+
+#endregion Part 3 - Generating Helm values
+
+########################################################################
+#              Part 4 - Connecting to cluster                          #
+########################################################################
+
+#region Part 4 - Connecting to cluster
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 4 of 6 — Connecting to cluster' -PercentComplete 50 -ErrorAction SilentlyContinue
+Write-Verbose 'Connecting to cluster...'
+
+try {
+    Import-AzAksCredential -ResourceGroupName $ResourceGroupName -Name $ClusterName -Force -ErrorAction Stop
+    Write-Verbose 'AKS credentials imported.'
+}
+catch {
+    Write-Verbose "Failed to import AKS credentials for '$ClusterName': $($_.Exception.Message)"
+    throw
+}
+
+try {
+    kubelogin convert-kubeconfig -l azurecli
+    Assert-ExitCode 'kubelogin convert-kubeconfig failed.'
+    Write-Verbose 'kubectl configured.'
+}
+catch {
+    Write-Verbose "kubelogin failed: $($_.Exception.Message)"
+    throw
+}
+
+#endregion Part 4 - Connecting to cluster
+
+########################################################################
+#              Part 5 - Installing Radius                              #
+########################################################################
+
+#region Part 5 - Installing Radius
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 5 of 6 — Installing Radius' -PercentComplete 67 -ErrorAction SilentlyContinue
+Write-Verbose 'Installing Radius...'
+
+try {
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Radius install' -Status 'Running rad install kubernetes — this may take a while...' -PercentComplete 50 -ErrorAction SilentlyContinue
+    rad install kubernetes --values "$GeneratedDir/radius/radius-values.yaml"
+    Assert-ExitCode 'rad install kubernetes failed.'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Radius install' -Completed -ErrorAction SilentlyContinue
+    Write-Verbose 'Radius installed and ready.'
+}
+catch {
+    Write-Verbose "Radius installation failed: $($_.Exception.Message)"
+    throw
+}
+
+#endregion Part 5 - Installing Radius
+
+########################################################################
+#              Part 6 - Configuring Radius                             #
+########################################################################
+
+#region Part 6 - Configuring Radius
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Status 'Part 6 of 6 — Configuring Radius' -PercentComplete 83 -ErrorAction SilentlyContinue
+
+try {
+    Write-Verbose 'Registering Azure credential (Workload Identity)...'
+    rad credential register azure wi --client-id $ClientId --tenant-id $TenantId
+    Assert-ExitCode 'rad credential register failed.'
+    Write-Verbose 'Azure credential registered.'
+}
+catch {
+    Write-Verbose "Failed to register Azure credential: $($_.Exception.Message)"
+    throw
+}
+
+try {
+    Write-Verbose 'Creating Radius environment...'
+    rad env create dev --namespace default
+    Assert-ExitCode 'rad env create failed.'
+
+    Write-Verbose 'Configuring Azure cloud provider for environment...'
+    rad env update dev `
+        --azure-subscription-id $SubscriptionId `
+        --azure-resource-group $ResourceGroupName
+    Assert-ExitCode 'rad env update failed.'
+    Write-Verbose 'Radius environment configured.'
+}
+catch {
+    Write-Verbose "Failed to configure Radius environment: $($_.Exception.Message)"
+    throw
+}
+
+Write-Progress -Id 0 -Activity 'Radius deployment' -Completed -ErrorAction SilentlyContinue
+
+#endregion Part 6 - Configuring Radius
+
+Write-Verbose "All done. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
+
+Write-Host ''
+Write-Host 'Radius is ready. To deploy the example application:' -ForegroundColor Green
+Write-Host "  rad deploy $ScriptRoot/kubernetes/examples/app.bicep --environment dev"
+Write-Host '  rad app graph demo'
+Write-Host ''
+Write-Host 'To clean up everything:'
+Write-Host "  .\Deploy.ps1 -Cleanup"

--- a/Radius/infrastructure/aks.bicep
+++ b/Radius/infrastructure/aks.bicep
@@ -1,0 +1,57 @@
+param clusterName string
+param location string
+param clusterAdminPrincipalId string
+
+resource aks 'Microsoft.ContainerService/managedClusters@2024-09-02-preview' = {
+  name: clusterName
+  location: location
+  sku: {
+    name: 'Automatic'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    dnsPrefix: clusterName
+    agentPoolProfiles: [
+      {
+        name: 'systempool'
+        mode: 'System'
+        count: 3
+        vmSize: 'Standard_D4ds_v5'
+      }
+    ]
+    oidcIssuerProfile: {
+      enabled: true
+    }
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
+    safeguardsProfile: {
+      level: 'Warning'
+    }
+  }
+}
+
+// Azure Kubernetes Service RBAC Cluster Admin
+var aksRbacClusterAdminRoleId = 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
+
+resource aksRbacClusterAdminRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: aksRbacClusterAdminRoleId
+}
+
+resource clusterAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aks.id, clusterAdminPrincipalId, aksRbacClusterAdminRole.id)
+  scope: aks
+  properties: {
+    principalId: clusterAdminPrincipalId
+    principalType: 'User'
+    roleDefinitionId: aksRbacClusterAdminRole.id
+  }
+}
+
+output clusterName string = aks.name
+output oidcIssuerUrl string = aks.properties.oidcIssuerProfile.issuerURL

--- a/Radius/infrastructure/main.bicep
+++ b/Radius/infrastructure/main.bicep
@@ -1,0 +1,27 @@
+@description('Project name used for resource naming')
+param projectName string = 'radius'
+
+@description('Azure region for all resources')
+param location string = 'swedencentral'
+
+@description('Principal ID of the user to assign AKS RBAC Cluster Admin')
+param clusterAdminPrincipalId string
+
+module aks 'aks.bicep' = {
+  params: {
+    clusterName: 'aks-${projectName}'
+    location: location
+    clusterAdminPrincipalId: clusterAdminPrincipalId
+  }
+}
+
+module radiusIdentity 'radiusIdentity.bicep' = {
+  params: {
+    identityName: 'id-${projectName}-azure-provider'
+    location: location
+    oidcIssuerUrl: aks.outputs.oidcIssuerUrl
+  }
+}
+
+output clusterName string = aks.outputs.clusterName
+output radiusIdentityClientId string = radiusIdentity.outputs.clientId

--- a/Radius/infrastructure/radiusIdentity.bicep
+++ b/Radius/infrastructure/radiusIdentity.bicep
@@ -1,0 +1,43 @@
+param identityName string
+param location string
+param oidcIssuerUrl string
+param serviceAccountNamespace string = 'radius-system'
+param serviceAccountName string = 'ucp'
+
+// Managed identity for the Radius UCP (Universal Control Plane) component
+resource radiusIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: identityName
+  location: location
+}
+
+// Federated credential linking AKS OIDC to the Radius UCP service account
+resource federatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  parent: radiusIdentity
+  name: 'radius-azure-provider'
+  properties: {
+    issuer: oidcIssuerUrl
+    subject: 'system:serviceaccount:${serviceAccountNamespace}:${serviceAccountName}'
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+  }
+}
+
+// Contributor role on the resource group
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+resource contributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: contributorRoleId
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, radiusIdentity.id, contributorRoleDefinition.id)
+  properties: {
+    principalId: radiusIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinition.id
+  }
+}
+
+output clientId string = radiusIdentity.properties.clientId

--- a/Radius/kubernetes/examples/app.bicep
+++ b/Radius/kubernetes/examples/app.bicep
@@ -1,0 +1,25 @@
+import radius as radius from 'br:ghcr.io/radius-project/rad-bicep-types:latest'
+
+@description('Radius environment to deploy into. Passed automatically by "rad deploy --environment".')
+param environment string
+
+resource app 'Applications.Core/applications@2023-10-01-preview' = {
+  name: 'demo'
+  properties: {
+    environment: environment
+  }
+}
+
+resource container 'Applications.Core/containers@2023-10-01-preview' = {
+  name: 'demo-container'
+  properties: {
+    application: app.id
+    container: {
+      image: 'nginx:latest'
+      ports: {
+        web: { containerPort: 80 }
+      }
+    }
+    connections: {}
+  }
+}

--- a/Radius/kubernetes/radius/radius-values.yaml
+++ b/Radius/kubernetes/radius/radius-values.yaml
@@ -1,0 +1,7 @@
+# Helm values for Radius
+# Enable Azure Workload Identity support so the UCP service account can exchange
+# AKS OIDC tokens for Azure credentials without storing secrets in the cluster.
+global:
+  azureWorkloadIdentity:
+    enabled: true
+    clientId: "<RADIUS_IDENTITY_CLIENT_ID>"

--- a/Radius/kubernetes/recipes/README.md
+++ b/Radius/kubernetes/recipes/README.md
@@ -1,0 +1,8 @@
+# Future home for Radius recipes
+#
+# This folder will contain:
+# - Environment recipes — map portable resource types to Azure resource templates
+# - Bicep/Terraform recipe templates for common building blocks (storage, databases, etc.)
+# - Recipe registrations linking resource types to recipe templates
+#
+# The Radius environment in ../examples/ must exist before registering recipes here.

--- a/Radius/readme.md
+++ b/Radius/readme.md
@@ -1,0 +1,198 @@
+# Radius on AKS Automatic
+
+This demo deploys an AKS Automatic cluster with Radius and the Azure cloud provider configured using Workload Identity.
+
+## Repository structure
+
+```
+Radius/
+├── Deploy.ps1               # One-command bootstrap script
+├── infrastructure/          # Bicep templates for Azure resources
+│   ├── main.bicep           # Orchestrator — deploys AKS + identity
+│   ├── aks.bicep            # AKS Automatic cluster
+│   └── radiusIdentity.bicep # Managed identity + federated credential for Radius UCP
+├── kubernetes/
+│   ├── radius/              # Helm values for Radius installation
+│   │   └── radius-values.yaml
+│   ├── recipes/             # Future home for Radius environment recipes
+│   │   └── README.md
+│   └── examples/            # Sample Radius applications
+│       └── app.bicep
+└── readme.md
+```
+
+## What gets deployed
+
+**Bicep (infrastructure):**
+- AKS Automatic cluster (system-assigned identity) with OIDC issuer and workload identity enabled
+- AKS RBAC Cluster Admin role assignment for the deploying user
+- User-assigned managed identity for the Radius UCP component
+- Federated identity credential linking AKS to the Radius UCP service account (`radius-system/ucp`)
+- Contributor role assignment on the resource group
+
+**Kubernetes (via rad CLI):**
+- Radius (via `rad install kubernetes`, Azure Workload Identity enabled)
+- Azure cloud provider credential (`rad credential register azure wi`)
+- Radius environment `dev` scoped to the resource group (`rad env create` + `rad env update`)
+
+## Prerequisites
+
+- Azure PowerShell (`Az.Accounts`, `Az.Resources`, `Az.Aks` modules) with an active login (`Connect-AzAccount`)
+  - The deploy script will auto-install missing modules into the CurrentUser scope
+- `kubectl` and `kubelogin`
+- `rad` CLI — [installation guide](https://docs.radapp.io/installation/)
+
+## Quick start
+
+`Deploy.ps1` automates all the steps below into a single command:
+
+```powershell
+cd Radius
+.\Deploy.ps1
+```
+
+Use `-SkipInfrastructure` to skip Bicep deployment when re-running against an existing cluster.
+
+The script writes generated files (with placeholders replaced) to `.generated/` so the originals stay reusable as templates.
+
+---
+
+## Manual steps (reference)
+
+## 1. Deploy infrastructure
+
+```powershell
+$rgName = "rg-radius"
+
+New-AzResourceGroup -Name $rgName -Location swedencentral -Force
+
+$principalId = (Get-AzADUser -SignedIn).Id
+
+New-AzResourceGroupDeployment `
+  -Name 'main' `
+  -ResourceGroupName $rgName `
+  -TemplateFile infrastructure/main.bicep `
+  -clusterAdminPrincipalId $principalId
+```
+
+Save the outputs — you'll need them for subsequent steps:
+
+```powershell
+$deployment = Get-AzResourceGroupDeployment -ResourceGroupName $rgName -Name 'main'
+
+$clusterName = $deployment.Outputs['clusterName'].Value
+$clientId    = $deployment.Outputs['radiusIdentityClientId'].Value
+$context     = Get-AzContext
+$subscriptionId = $context.Subscription.Id
+$tenantId       = $context.Tenant.Id
+```
+
+## 2. Replace placeholders in Helm values
+
+The Helm values file uses an angle-bracket placeholder for the managed identity client ID:
+
+| Placeholder | Value | Used in |
+|---|---|---|
+| `<RADIUS_IDENTITY_CLIENT_ID>` | `$clientId` | `radius-values.yaml` |
+
+```powershell
+(Get-Content kubernetes/radius/radius-values.yaml -Raw) `
+    -replace '<RADIUS_IDENTITY_CLIENT_ID>', $clientId |
+    Set-Content kubernetes/radius/radius-values.yaml
+```
+
+## 3. Connect to the cluster
+
+```powershell
+Import-AzAksCredential -ResourceGroupName $rgName -Name $clusterName -Force
+kubelogin convert-kubeconfig -l azurecli
+```
+
+> **Note:** AKS Automatic uses Entra ID authentication. The `kubelogin convert-kubeconfig -l azurecli` command configures kubectl to reuse your existing `az login` session, which avoids Conditional Access issues with interactive browser sign-in.
+
+## 4. Install Radius
+
+```powershell
+rad install kubernetes --values kubernetes/radius/radius-values.yaml
+```
+
+The `global.azureWorkloadIdentity.enabled=true` value in `radius-values.yaml` tells Radius to annotate the `ucp` service account with the managed identity client ID, enabling the UCP pod to exchange AKS OIDC tokens for Azure credentials.
+
+Wait for Radius pods to be ready:
+
+```powershell
+kubectl get pods -n radius-system -w
+```
+
+## 5. Register the Azure credential
+
+```powershell
+rad credential register azure wi --client-id $clientId --tenant-id $tenantId
+```
+
+Radius stores this in the cluster and uses it when provisioning Azure resources from recipes.
+
+## 6. Create a Radius environment
+
+```powershell
+rad env create dev --namespace default
+rad env update dev `
+  --azure-subscription-id $subscriptionId `
+  --azure-resource-group $rgName
+```
+
+The environment scopes Azure resource provisioning to a specific subscription and resource group.
+
+## 7. Verify
+
+```powershell
+# Credential should show as registered
+rad credential list
+
+# Environment should exist
+rad env list
+```
+
+## 8. Try it out — deploy the example application
+
+```powershell
+rad deploy kubernetes/examples/app.bicep --environment dev
+```
+
+This deploys a simple nginx container managed by Radius. Inspect the application graph:
+
+```powershell
+rad app graph demo
+```
+
+List running applications:
+
+```powershell
+rad app list
+```
+
+Delete the application when done:
+
+```powershell
+rad app delete demo
+```
+
+## Cleanup
+
+```powershell
+.\Deploy.ps1 -Cleanup
+```
+
+Or manually:
+
+```powershell
+Remove-AzResourceGroup -Name $rgName -Force -AsJob
+```
+
+## Next steps
+
+With Radius installed and an Azure environment configured, you can:
+
+- **Add recipes** — define reusable infrastructure templates that map portable resource types (e.g. `Applications.Datastores/redisCaches`) to Azure resources. See `kubernetes/recipes/` for a placeholder.
+- **Deploy real applications** — extend `app.bicep` to include connections to Azure resources provisioned via recipes.
+- **Explore the Radius dashboard** — `rad dashboard` opens a local web UI showing all applications and their connections.


### PR DESCRIPTION
## Motivation

The repo already has a Crossplane-on-AKS-Automatic demo showing how to manage Azure resources via a Kubernetes-native control plane. This PR adds the equivalent for [Radius](https://radapp.io/) — Microsoft's open-source cloud-native application platform — so both approaches can be compared side by side.

## What's in here

The structure deliberately mirrors `Crossplane/` so it's easy to diff the two approaches:

```
Radius/
├── Deploy.ps1                         # One-command bootstrap (6 parts, same pattern as Crossplane)
├── infrastructure/
│   ├── main.bicep                     # Orchestrator — AKS + managed identity
│   ├── aks.bicep                      # AKS Automatic cluster (OIDC + workload identity)
│   └── radiusIdentity.bicep           # Managed identity federated to radius-system/ucp
├── kubernetes/
│   ├── radius/radius-values.yaml      # Helm values — enables Azure Workload Identity on UCP
│   ├── recipes/README.md              # Placeholder for future environment recipes
│   └── examples/app.bicep             # Example Radius app (nginx container via rad deploy)
└── readme.md                          # Full manual reference + quick start
```

**Key design decisions:**

- **Federated credential targets `radius-system/ucp`** — the UCP (Universal Control Plane) is the Radius component that makes Azure API calls, so that's where the OIDC trust needs to land (vs. `crossplane-system/provider-azure` in the Crossplane demo).
- **`rad` CLI for provider/env config** — Radius doesn't use raw `kubectl apply` for credential or environment setup; `rad credential register azure wi` and `rad env create/update` are the idiomatic equivalents of Crossplane's `ProviderConfig` and provider YAML manifests.
- **Helm values carry the client ID at install time** — `radius-values.yaml` has a `<RADIUS_IDENTITY_CLIENT_ID>` placeholder that gets replaced in `.generated/` (same pattern as Crossplane), so the UCP service account is annotated correctly before the pod starts.
- **Example is a Bicep app** — Radius is Bicep-native, so `app.bicep` + `rad deploy` is the natural parallel to Crossplane's `storage-account.yaml` + `kubectl apply`.
- **`recipes/`** is the Radius analog to Crossplane's `platform/` (XRDs/Compositions) — a placeholder for reusable infrastructure templates.