### PR TITLE
Clarify Crossplane Quick Start with what gets deployed

### DIFF
--- a/Crossplane/readme.md
+++ b/Crossplane/readme.md
@@ -57,6 +57,25 @@ cd Crossplane
 .\Deploy.ps1 -StorageAccountName "mystgcrossplane01"
 ```
 
+The script deploys the following end to end:
+
+1. **Azure infrastructure** (via Bicep) — AKS Automatic cluster, managed identity, and federated credential
+2. **Crossplane** (via Helm) — installed into the `crossplane-system` namespace
+3. **Azure provider** — `provider-family-azure` and `provider-azure-storage`, configured with Workload Identity
+
+When the script finishes, Crossplane is fully operational and ready to manage Azure resources. The `-StorageAccountName` value is pre-filled into the example manifest so you can immediately try it out:
+
+```powershell
+kubectl apply -f .generated/examples/storage-account.yaml
+kubectl get account.storage.azure.upbound.io -w
+```
+
+This creates a real Azure Storage Account (Standard LRS, Sweden Central) managed by Crossplane. Once `READY=True` and `SYNCED=True`, the account exists in Azure. Delete the manifest to have Crossplane remove it automatically.
+
+---
+
+**Flags:**
+
 Use `-SkipInfrastructure` to skip Bicep deployment when re-running against an existing cluster.
 
 Use `-Cleanup` to tear down everything (resource group + `.generated/` folder).


### PR DESCRIPTION
The Quick Start section previously just showed the one-liner command and some flags, leaving readers to figure out on their own what the script actually does and what to expect when it finishes.

This PR rewrites the Quick Start to answer the key questions up front:

- **What does the script deploy?** Three clearly numbered steps — Azure infra (Bicep), Crossplane (Helm), and the Azure provider.
- **What do you do after?** The storage account example is now surfaced directly in Quick Start, with the exact commands to apply and watch it provision.
- **What does the example actually create?** Explicitly called out as a real Azure Storage Account (Standard LRS, Sweden Central), with a note that deleting the manifest triggers automatic cleanup in Azure.

The flags (`-SkipInfrastructure`, `-Cleanup`, overrides) are moved to a clearly labelled **Flags** section at the bottom so they don't interrupt the main flow.

No code changes — documentation only.