### PR TITLE
feat: add Azure Service Operator quickstart

### DIFF
--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -1,0 +1,390 @@
+<#
+.SYNOPSIS
+    Deploys the Azure Service Operator (ASO) on AKS Automatic demo end to end.
+
+.DESCRIPTION
+    Automates: resource group creation, Bicep deployment, AKS credential setup,
+    ASO installation via Helm, placeholder replacement in YAML manifests,
+    and an optional example StorageAccount deployment.
+
+    Uses Azure PowerShell cmdlets (Az module) for all Azure operations — these
+    throw terminating errors on failure, so the script halts immediately if
+    anything goes wrong. External tools (kubectl, helm, kubelogin) are checked
+    via exit code after each call.
+
+    Original YAML files are left untouched — generated copies with real values
+    are written to .generated/ and applied from there.
+
+.PARAMETER ResourceGroupName
+    Name of the Azure resource group. Default: rg-aso.
+
+.PARAMETER Location
+    Azure region for all resources. Default: swedencentral.
+
+.PARAMETER StorageAccountName
+    Globally unique name for the example storage account (3-24 chars, lowercase + numbers).
+
+.PARAMETER SkipInfrastructure
+    Skip Bicep deployment and resource group creation. Useful when re-running
+    only the Kubernetes configuration steps against an existing cluster.
+
+.PARAMETER Cleanup
+    Tears down everything: deletes the Azure resource group (and all resources
+    within it) and removes the local .generated/ folder.
+
+.LINK
+    https://azure.github.io/azure-service-operator/
+
+.EXAMPLE
+    .\Deploy.ps1
+    .\Deploy.ps1 -StorageAccountName "mystgaso01"
+    .\Deploy.ps1 -SkipInfrastructure
+    .\Deploy.ps1 -Cleanup
+#>
+
+[CmdletBinding()]
+param(
+    [string]$ResourceGroupName = 'rg-aso',
+    [string]$Location = 'swedencentral',
+    [string]$StorageAccountName = 'youruniquestoragename',
+    [switch]$SkipInfrastructure,
+    [switch]$Cleanup
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Script related variables
+$ScriptRoot = $PSScriptRoot
+$GeneratedDir = Join-Path $ScriptRoot '.generated'
+
+# Module related variables
+$RequiredModules = @('Az.Accounts', 'Az.Resources', 'Az.Aks')
+
+########################################################################
+#                     DO NOT EDIT BELOW THIS LINE                      #
+########################################################################
+
+$ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
+
+########################################################################
+#                          Preparations                                #
+########################################################################
+
+#region Preparations
+
+Write-Verbose 'Ensuring required Az modules are installed.'
+
+$Progress = 0
+foreach ($Module in $RequiredModules) {
+    Write-Progress -Activity 'Checking Az modules' -Status $Module -PercentComplete ($Progress / $RequiredModules.Count * 100) -ErrorAction SilentlyContinue
+    if (-not (Get-Module -Name $Module -ListAvailable)) {
+        Write-Verbose "Installing missing module '$Module'..."
+        Install-Module -Name $Module -Scope CurrentUser -Force -AllowClobber
+        Write-Verbose "Module '$Module' installed successfully."
+    }
+    Import-Module $Module -ErrorAction Stop
+    Write-Verbose "Module '$Module' loaded."
+    $Progress++
+}
+Write-Progress -Activity 'Checking Az modules' -Completed -ErrorAction SilentlyContinue
+
+#endregion Preparations
+
+########################################################################
+#                            Cleanup                                   #
+########################################################################
+
+#region Cleanup
+
+if ($Cleanup) {
+    Write-Verbose 'Cleanup mode activated.'
+
+    # Resolve the resource group name from the saved deployment context
+    $ContextFile = Join-Path $GeneratedDir 'deployment-context.json'
+    if (Test-Path $ContextFile) {
+        $SavedContext = Get-Content $ContextFile -Raw | ConvertFrom-Json
+        $ResourceGroupName = $SavedContext.ResourceGroupName
+        Write-Verbose "Loaded resource group name '$ResourceGroupName' from deployment context."
+    }
+    else {
+        Write-Warning "No deployment context found in .generated/ — using parameter value '$ResourceGroupName'. Verify this is the correct resource group before continuing."
+    }
+
+    $ResourceGroup = Get-AzResourceGroup -Name $ResourceGroupName -ErrorAction SilentlyContinue
+    if ($ResourceGroup) {
+        Write-Verbose "Deleting resource group '$ResourceGroupName'..."
+        Remove-AzResourceGroup -Name $ResourceGroupName -Force
+        Write-Verbose "Resource group '$ResourceGroupName' deleted."
+    }
+    else {
+        Write-Verbose "Resource group '$ResourceGroupName' not found — nothing to delete."
+    }
+
+    if (Test-Path $GeneratedDir) {
+        Write-Verbose 'Removing .generated/ folder...'
+        Remove-Item $GeneratedDir -Recurse -Force
+        Write-Verbose 'Removed .generated/ folder.'
+    }
+
+    Write-Verbose "Cleanup complete. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
+    return
+}
+
+#endregion Cleanup
+
+function Assert-ExitCode {
+    <#
+    .SYNOPSIS
+        Throws if the last external command returned a non-zero exit code.
+    .PARAMETER Message
+        Error message to include in the thrown exception.
+    .EXAMPLE
+        Assert-ExitCode 'kubectl apply failed.'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, HelpMessage = 'Error message to throw on failure.')]
+        [string]$Message
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Message (exit code: $LASTEXITCODE)"
+    }
+}
+
+########################################################################
+#               Part 1 - Deploying infrastructure                     #
+########################################################################
+
+#region Part 1 - Deploying infrastructure
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 1 of 5 — Deploying infrastructure' -PercentComplete 0 -ErrorAction SilentlyContinue
+
+if (-not $SkipInfrastructure) {
+    Write-Verbose 'Deploying infrastructure...'
+
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Creating resource group...' -PercentComplete 0 -ErrorAction SilentlyContinue
+    try {
+        New-AzResourceGroup -Name $ResourceGroupName -Location $Location -Force | Out-Null
+        Write-Verbose "Resource group '$ResourceGroupName' ready."
+    }
+    catch {
+        Write-Verbose "Failed to create resource group '$ResourceGroupName': $($_.Exception.Message)"
+        throw
+    }
+
+    # Save deployment context so cleanup can find the correct resource group
+    if (-not (Test-Path $GeneratedDir)) { New-Item -Path $GeneratedDir -ItemType Directory -Force | Out-Null }
+    @{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
+    Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
+
+    try {
+        $Context = Get-AzContext -ErrorAction Stop
+        if (-not $Context) { throw 'No Azure context found. Run Connect-AzAccount first.' }
+    }
+    catch {
+        Write-Verbose "Failed to get Azure context: $($_.Exception.Message)"
+        throw
+    }
+
+    try {
+        $PrincipalId = (Get-AzADUser -SignedIn -ErrorAction Stop).Id
+        if (-not $PrincipalId) { throw 'Could not determine signed-in user principal ID.' }
+        Write-Verbose "Signed-in user principal ID: $PrincipalId"
+    }
+    catch {
+        Write-Verbose "Failed to get signed-in user principal ID: $($_.Exception.Message)"
+        throw
+    }
+
+    Write-Verbose 'Starting Bicep deployment...'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Bicep deployment in progress — this may take a while...' -PercentComplete 25 -ErrorAction SilentlyContinue
+    try {
+        $DeploymentJob = New-AzResourceGroupDeployment `
+            -Name 'main' `
+            -ResourceGroupName $ResourceGroupName `
+            -TemplateFile "$ScriptRoot/infrastructure/main.bicep" `
+            -clusterAdminPrincipalId $PrincipalId `
+            -AsJob
+
+        while ($DeploymentJob.State -eq 'Running') {
+            Start-Sleep -Seconds 5
+            $MinutesElapsed = [math]::Round(((Get-Date) - $DeploymentJob.PSBeginTime).TotalMinutes, 1)
+            Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status "Bicep deployment in progress — $MinutesElapsed min elapsed" -PercentComplete 50 -ErrorAction SilentlyContinue
+        }
+
+        $DeploymentJob | Receive-Job -Wait -AutoRemoveJob | Out-Null
+        Write-Verbose 'Bicep deployment complete.'
+    }
+    catch {
+        Write-Verbose "Bicep deployment failed: $($_.Exception.Message)"
+        throw
+    }
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Completed -ErrorAction SilentlyContinue
+}
+else {
+    Write-Verbose 'Skipping infrastructure deployment (SkipInfrastructure flag set).'
+}
+
+#endregion Part 1 - Deploying infrastructure
+
+########################################################################
+#             Part 2 - Capturing deployment outputs                    #
+########################################################################
+
+#region Part 2 - Capturing deployment outputs
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 2 of 5 — Capturing deployment outputs' -PercentComplete 20 -ErrorAction SilentlyContinue
+Write-Verbose 'Capturing deployment outputs...'
+
+try {
+    $Deployment = Get-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -Name 'main' -ErrorAction Stop
+    Write-Verbose 'Retrieved deployment outputs.'
+}
+catch {
+    Write-Verbose "Failed to get deployment '$ResourceGroupName/main': $($_.Exception.Message)"
+    throw
+}
+
+$ClusterName = $Deployment.Outputs['clusterName'].Value
+$ClientId    = $Deployment.Outputs['asoIdentityClientId'].Value
+
+try {
+    $Context        = Get-AzContext -ErrorAction Stop
+    $SubscriptionId = $Context.Subscription.Id
+    $TenantId       = $Context.Tenant.Id
+}
+catch {
+    Write-Verbose "Failed to get Azure context: $($_.Exception.Message)"
+    throw
+}
+
+Write-Verbose "Cluster:        $ClusterName"
+Write-Verbose "Client ID:      $ClientId"
+Write-Verbose "Subscription:   $SubscriptionId"
+Write-Verbose "Tenant:         $TenantId"
+
+#endregion Part 2 - Capturing deployment outputs
+
+########################################################################
+#             Part 3 - Generating YAML manifests                       #
+########################################################################
+
+#region Part 3 - Generating YAML manifests
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 3 of 5 — Generating YAML manifests' -PercentComplete 40 -ErrorAction SilentlyContinue
+Write-Verbose 'Generating YAML manifests...'
+
+if (Test-Path $GeneratedDir) { Remove-Item $GeneratedDir -Recurse -Force }
+
+Copy-Item -Path (Join-Path $ScriptRoot 'kubernetes') -Destination $GeneratedDir -Recurse
+
+$YamlFiles = Get-ChildItem -Path $GeneratedDir -Recurse -Filter *.yaml
+
+$Progress = 0
+foreach ($File in $YamlFiles) {
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Processing YAML manifests' -Status $File.Name -PercentComplete ($Progress / $YamlFiles.Count * 100) -ErrorAction SilentlyContinue
+    (Get-Content $File.FullName -Raw) `
+        -replace '<ASO_IDENTITY_CLIENT_ID>', $ClientId `
+        -replace '<SUBSCRIPTION_ID>', $SubscriptionId `
+        -replace '<TENANT_ID>', $TenantId `
+        -replace '<RESOURCE_GROUP_NAME>', $ResourceGroupName `
+        -replace '<STORAGE_ACCOUNT_NAME>', $StorageAccountName |
+        Set-Content $File.FullName
+    $Progress++
+}
+Write-Progress -Id 1 -ParentId 0 -Activity 'Processing YAML manifests' -Completed -ErrorAction SilentlyContinue
+
+Write-Verbose "Generated manifests in $GeneratedDir"
+
+#endregion Part 3 - Generating YAML manifests
+
+########################################################################
+#              Part 4 - Connecting to cluster                          #
+########################################################################
+
+#region Part 4 - Connecting to cluster
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 4 of 5 — Connecting to cluster' -PercentComplete 60 -ErrorAction SilentlyContinue
+Write-Verbose 'Connecting to cluster...'
+
+try {
+    Import-AzAksCredential -ResourceGroupName $ResourceGroupName -Name $ClusterName -Force -ErrorAction Stop
+    Write-Verbose 'AKS credentials imported.'
+}
+catch {
+    Write-Verbose "Failed to import AKS credentials for '$ClusterName': $($_.Exception.Message)"
+    throw
+}
+
+try {
+    kubelogin convert-kubeconfig -l azurecli
+    Assert-ExitCode 'kubelogin convert-kubeconfig failed.'
+    Write-Verbose 'kubectl configured.'
+}
+catch {
+    Write-Verbose "kubelogin failed: $($_.Exception.Message)"
+    throw
+}
+
+#endregion Part 4 - Connecting to cluster
+
+########################################################################
+#              Part 5 - Installing ASO                                 #
+########################################################################
+
+#region Part 5 - Installing ASO
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 5 of 5 — Installing Azure Service Operator' -PercentComplete 80 -ErrorAction SilentlyContinue
+Write-Verbose 'Installing Azure Service Operator...'
+
+# Remove the ValidatingAdmissionPolicy binding that may conflict with ASO webhooks on AKS Automatic
+kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found 2>$null
+# Intentionally not checking exit code — binding may already be absent
+
+try {
+    Write-Verbose 'Adding ASO Helm repo...'
+    helm repo add asohelmchart https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts --force-update | Out-Null
+    Assert-ExitCode 'helm repo add failed.'
+
+    helm repo update | Out-Null
+    Assert-ExitCode 'helm repo update failed.'
+    Write-Verbose 'Helm repo configured.'
+}
+catch {
+    Write-Verbose "Failed to configure Helm repo: $($_.Exception.Message)"
+    throw
+}
+
+try {
+    Write-Verbose 'Installing ASO via Helm...'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
+    helm upgrade aso asohelmchart/aso-helm-chart `
+        --install `
+        --namespace azureserviceoperator-system `
+        --create-namespace `
+        --values "$GeneratedDir/aso-values.yaml" `
+        --wait
+    Assert-ExitCode 'helm upgrade/install aso failed.'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Completed -ErrorAction SilentlyContinue
+    Write-Verbose 'ASO installed and ready.'
+}
+catch {
+    Write-Verbose "Helm install/upgrade failed: $($_.Exception.Message)"
+    throw
+}
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Completed -ErrorAction SilentlyContinue
+
+#endregion Part 5 - Installing ASO
+
+Write-Verbose "All done. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
+
+Write-Host ''
+Write-Host 'Azure Service Operator is ready. To test with a Storage Account:' -ForegroundColor Green
+Write-Host "  kubectl apply -f $GeneratedDir/examples/storage-account.yaml"
+Write-Host '  kubectl get storageaccount -w'
+Write-Host ''
+Write-Host 'To clean up everything:'
+Write-Host "  .\Deploy.ps1 -Cleanup"

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -276,10 +276,21 @@ Write-Verbose "Tenant:         $TenantId"
 Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 3 of 5 — Generating YAML manifests' -PercentComplete 40 -ErrorAction SilentlyContinue
 Write-Verbose 'Generating YAML manifests...'
 
+$DeploymentContextFileName = 'deployment-context.json'
+$DeploymentContextPath = Join-Path $GeneratedDir $DeploymentContextFileName
+$DeploymentContextContent = $null
+
+if (Test-Path $DeploymentContextPath) {
+    $DeploymentContextContent = Get-Content -Path $DeploymentContextPath -Raw
+}
+
 if (Test-Path $GeneratedDir) { Remove-Item $GeneratedDir -Recurse -Force }
 
 Copy-Item -Path (Join-Path $ScriptRoot 'kubernetes') -Destination $GeneratedDir -Recurse
 
+if ($null -ne $DeploymentContextContent) {
+    Set-Content -Path (Join-Path $GeneratedDir $DeploymentContextFileName) -Value $DeploymentContextContent
+}
 $YamlFiles = Get-ChildItem -Path $GeneratedDir -Recurse -Filter *.yaml
 
 $Progress = 0

--- a/AzureServiceOperator/infrastructure/aks.bicep
+++ b/AzureServiceOperator/infrastructure/aks.bicep
@@ -1,0 +1,57 @@
+param clusterName string
+param location string
+param clusterAdminPrincipalId string
+
+resource aks 'Microsoft.ContainerService/managedClusters@2024-09-02-preview' = {
+  name: clusterName
+  location: location
+  sku: {
+    name: 'Automatic'
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    dnsPrefix: clusterName
+    agentPoolProfiles: [
+      {
+        name: 'systempool'
+        mode: 'System'
+        count: 3
+        vmSize: 'Standard_D4ds_v5'
+      }
+    ]
+    oidcIssuerProfile: {
+      enabled: true
+    }
+    securityProfile: {
+      workloadIdentity: {
+        enabled: true
+      }
+    }
+    safeguardsProfile: {
+      level: 'Warning'
+    }
+  }
+}
+
+// Azure Kubernetes Service RBAC Cluster Admin
+var aksRbacClusterAdminRoleId = 'b1ff04bb-8a4e-4dc4-8eb5-8693973ce19b'
+
+resource aksRbacClusterAdminRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: aksRbacClusterAdminRoleId
+}
+
+resource clusterAdminRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(aks.id, clusterAdminPrincipalId, aksRbacClusterAdminRole.id)
+  scope: aks
+  properties: {
+    principalId: clusterAdminPrincipalId
+    principalType: 'User'
+    roleDefinitionId: aksRbacClusterAdminRole.id
+  }
+}
+
+output clusterName string = aks.name
+output oidcIssuerUrl string = aks.properties.oidcIssuerProfile.issuerURL

--- a/AzureServiceOperator/infrastructure/asoIdentity.bicep
+++ b/AzureServiceOperator/infrastructure/asoIdentity.bicep
@@ -1,0 +1,45 @@
+param identityName string
+param location string
+param oidcIssuerUrl string
+
+// ASO v2 operator service account — namespace and name are fixed by the Helm chart
+param serviceAccountNamespace string = 'azureserviceoperator-system'
+param serviceAccountName string = 'azureserviceoperator-default'
+
+// Managed identity for the ASO operator
+resource asoIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: identityName
+  location: location
+}
+
+// Federated credential linking AKS OIDC to the ASO operator service account
+resource federatedCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+  parent: asoIdentity
+  name: 'aso-operator'
+  properties: {
+    issuer: oidcIssuerUrl
+    subject: 'system:serviceaccount:${serviceAccountNamespace}:${serviceAccountName}'
+    audiences: [
+      'api://AzureADTokenExchange'
+    ]
+  }
+}
+
+// Contributor role on the resource group
+var contributorRoleId = 'b24988ac-6180-42a0-ab88-20f7382dd24c'
+
+resource contributorRoleDefinition 'Microsoft.Authorization/roleDefinitions@2022-04-01' existing = {
+  scope: subscription()
+  name: contributorRoleId
+}
+
+resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(resourceGroup().id, asoIdentity.id, contributorRoleDefinition.id)
+  properties: {
+    principalId: asoIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: contributorRoleDefinition.id
+  }
+}
+
+output clientId string = asoIdentity.properties.clientId

--- a/AzureServiceOperator/infrastructure/main.bicep
+++ b/AzureServiceOperator/infrastructure/main.bicep
@@ -1,0 +1,27 @@
+@description('Project name used for resource naming')
+param projectName string = 'aso'
+
+@description('Azure region for all resources')
+param location string = 'swedencentral'
+
+@description('Principal ID of the user to assign AKS RBAC Cluster Admin')
+param clusterAdminPrincipalId string
+
+module aks 'aks.bicep' = {
+  params: {
+    clusterName: 'aks-${projectName}'
+    location: location
+    clusterAdminPrincipalId: clusterAdminPrincipalId
+  }
+}
+
+module asoIdentity 'asoIdentity.bicep' = {
+  params: {
+    identityName: 'id-${projectName}-operator'
+    location: location
+    oidcIssuerUrl: aks.outputs.oidcIssuerUrl
+  }
+}
+
+output clusterName string = aks.outputs.clusterName
+output asoIdentityClientId string = asoIdentity.outputs.clientId

--- a/AzureServiceOperator/kubernetes/aso-values.yaml
+++ b/AzureServiceOperator/kubernetes/aso-values.yaml
@@ -1,0 +1,8 @@
+# Helm values for Azure Service Operator v2
+# Tested with ASO v2 (asohelmchart/aso-helm-chart)
+# Workload Identity authentication — no secrets stored in the cluster
+
+azureTenantID: "<TENANT_ID>"
+azureSubscriptionID: "<SUBSCRIPTION_ID>"
+azureClientID: "<ASO_IDENTITY_CLIENT_ID>"
+useWorkloadIdentityAuth: true

--- a/AzureServiceOperator/kubernetes/examples/storage-account.yaml
+++ b/AzureServiceOperator/kubernetes/examples/storage-account.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.azure.com/v1api20230101
+kind: StorageAccount
+metadata:
+  name: <STORAGE_ACCOUNT_NAME>
+  namespace: default
+spec:
+  location: swedencentral
+  owner:
+    armId: /subscriptions/<SUBSCRIPTION_ID>/resourceGroups/<RESOURCE_GROUP_NAME>
+  kind: StorageV2
+  sku:
+    name: Standard_LRS
+  accessTier: Hot

--- a/AzureServiceOperator/readme.md
+++ b/AzureServiceOperator/readme.md
@@ -1,0 +1,226 @@
+# Azure Service Operator on AKS Automatic
+
+This demo deploys an AKS Automatic cluster with Azure Service Operator (ASO) v2 configured using Workload Identity.
+
+## Repository structure
+
+```
+AzureServiceOperator/
+├── Deploy.ps1               # One-command bootstrap script
+├── infrastructure/          # Bicep templates for Azure resources
+│   ├── main.bicep           # Orchestrator — deploys AKS + identity
+│   ├── aks.bicep            # AKS Automatic cluster
+│   └── asoIdentity.bicep    # Managed identity + federated credential
+├── kubernetes/
+│   ├── aso-values.yaml      # Helm values for ASO install (with placeholders)
+│   └── examples/            # Sample managed resources
+│       └── storage-account.yaml
+└── readme.md
+```
+
+## What gets deployed
+
+**Bicep (infrastructure):**
+- AKS Automatic cluster (system-assigned identity) with OIDC issuer and workload identity enabled
+- AKS RBAC Cluster Admin role assignment for the deploying user
+- User-assigned managed identity for the ASO operator
+- Federated identity credential linking AKS to the ASO operator service account
+- Contributor role assignment on the resource group
+
+**Kubernetes (Helm + YAML manifests):**
+- Azure Service Operator v2 (via Helm), configured with Azure Workload Identity
+
+## Prerequisites
+
+- Azure PowerShell (`Az.Accounts`, `Az.Resources`, `Az.Aks` modules) with an active login (`Connect-AzAccount`)
+  - The deploy script will auto-install missing modules into the CurrentUser scope
+- `kubectl` and `kubelogin`
+- Helm 3
+
+## Quick start
+
+`Deploy.ps1` automates all the steps below into a single command:
+
+```powershell
+cd AzureServiceOperator
+.\Deploy.ps1 -StorageAccountName "mystgaso01"
+```
+
+The script deploys the following end to end:
+
+1. **Azure infrastructure** (via Bicep) — AKS Automatic cluster, managed identity, and federated credential
+2. **Azure Service Operator** (via Helm) — installed into the `azureserviceoperator-system` namespace, configured with Workload Identity
+
+When the script finishes, ASO is fully operational and ready to manage Azure resources. The `-StorageAccountName` value is pre-filled into the example manifest so you can immediately try it out:
+
+```powershell
+kubectl apply -f .generated/examples/storage-account.yaml
+kubectl get storageaccount -w
+```
+
+This creates a real Azure Storage Account (Standard LRS, Sweden Central) managed by ASO. Once `READY=True`, the account exists in Azure. Delete the manifest to have ASO remove it automatically.
+
+---
+
+**Flags:**
+
+Use `-SkipInfrastructure` to skip Bicep deployment when re-running against an existing cluster.
+
+Use `-Cleanup` to tear down everything (resource group + `.generated/` folder).
+
+Optional overrides: `-ResourceGroupName` (default: `rg-aso`), `-Location` (default: `swedencentral`).
+
+The script writes generated YAML (with placeholders replaced) to `.generated/` so the originals stay reusable as templates.
+
+---
+
+## Manual steps (reference)
+
+## 1. Deploy infrastructure
+
+```powershell
+$rgName = "rg-aso"
+
+New-AzResourceGroup -Name $rgName -Location swedencentral -Force
+
+$principalId = (Get-AzADUser -SignedIn).Id
+
+New-AzResourceGroupDeployment `
+  -Name 'main' `
+  -ResourceGroupName $rgName `
+  -TemplateFile infrastructure/main.bicep `
+  -clusterAdminPrincipalId $principalId
+```
+
+Save the outputs — you'll need them for placeholder replacement in the YAML files:
+
+```powershell
+$deployment = Get-AzResourceGroupDeployment -ResourceGroupName $rgName -Name 'main'
+
+$clusterName = $deployment.Outputs['clusterName'].Value
+$clientId = $deployment.Outputs['asoIdentityClientId'].Value
+$context = Get-AzContext
+$subscriptionId = $context.Subscription.Id
+$tenantId = $context.Tenant.Id
+```
+
+## 2. Replace placeholders in YAML files
+
+The Kubernetes manifests use angle-bracket placeholders for environment-specific values. Replace them before applying:
+
+| Placeholder | Value | Used in |
+|---|---|---|
+| `<ASO_IDENTITY_CLIENT_ID>` | `$clientId` | `aso-values.yaml` |
+| `<SUBSCRIPTION_ID>` | `$subscriptionId` | `aso-values.yaml`, `storage-account.yaml` |
+| `<TENANT_ID>` | `$tenantId` | `aso-values.yaml` |
+| `<RESOURCE_GROUP_NAME>` | `$rgName` | `storage-account.yaml` |
+| `<STORAGE_ACCOUNT_NAME>` | `$storageAccountName` | `storage-account.yaml` |
+
+```powershell
+$storageAccountName = 'youruniquestoragename'  # Replace with a globally unique name (3-24 chars, lowercase + numbers)
+
+$files = Get-ChildItem -Path kubernetes -Recurse -Filter *.yaml
+
+foreach ($file in $files) {
+    (Get-Content $file.FullName -Raw) `
+        -replace '<ASO_IDENTITY_CLIENT_ID>', $clientId `
+        -replace '<SUBSCRIPTION_ID>', $subscriptionId `
+        -replace '<TENANT_ID>', $tenantId `
+        -replace '<RESOURCE_GROUP_NAME>', $rgName `
+        -replace '<STORAGE_ACCOUNT_NAME>', $storageAccountName |
+        Set-Content $file.FullName
+}
+```
+
+## 3. Connect to the cluster
+
+```powershell
+Import-AzAksCredential -ResourceGroupName $rgName -Name $clusterName -Force
+kubelogin convert-kubeconfig -l azurecli
+```
+
+> **Note:** AKS Automatic uses Entra ID authentication. The `kubelogin convert-kubeconfig -l azurecli` command configures kubectl to reuse your existing `az login` session, which avoids Conditional Access issues with interactive browser sign-in.
+
+## 4. Install Azure Service Operator
+
+ASO is installed as a single Helm chart. The Workload Identity configuration is passed via the values file.
+
+```powershell
+helm repo add asohelmchart https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts
+helm repo update
+
+helm upgrade aso asohelmchart/aso-helm-chart `
+  --install `
+  --namespace azureserviceoperator-system `
+  --create-namespace `
+  --values kubernetes/aso-values.yaml `
+  --wait
+```
+
+> **Note:** If the install fails on AKS Automatic with a webhook or RBAC error, try removing the built-in `ValidatingAdmissionPolicyBinding` that blocks certain cluster-level operations before retrying:
+> ```powershell
+> kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found
+> ```
+> AKS will automatically recreate this binding after a reconciliation cycle.
+
+Wait for ASO pods to be ready:
+
+```powershell
+kubectl get pods -n azureserviceoperator-system -w
+```
+
+## 5. Verify
+
+```powershell
+# ASO manager pod should be Running
+kubectl get pods -n azureserviceoperator-system
+
+# Check operator logs for any auth errors
+kubectl logs -n azureserviceoperator-system -l control-plane=controller-manager --tail=20
+```
+
+## 6. Try it out — create a Storage Account
+
+```powershell
+kubectl apply -f kubernetes/examples/storage-account.yaml
+```
+
+Watch it provision:
+
+```powershell
+kubectl get storageaccount -w
+```
+
+Once `READY` is `True`, the storage account exists in Azure. You can verify with:
+
+```powershell
+Get-AzStorageAccount -ResourceGroupName $rgName -Name $storageAccountName | Select-Object StorageAccountName, ProvisioningState
+```
+
+> **Note:** The ASO identity has Contributor on `rg-aso` only, so all resources must be created within that resource group.
+
+Delete the managed resource when done:
+
+```powershell
+kubectl delete -f kubernetes/examples/storage-account.yaml
+```
+
+ASO will automatically delete the storage account from Azure.
+
+## Cleanup
+
+Use the `-Cleanup` flag to tear everything down — removes the Azure resource group and the local `.generated/` folder:
+
+```powershell
+.\Deploy.ps1 -Cleanup
+```
+
+Or manually:
+
+```powershell
+Remove-AzResourceGroup -Name $rgName -Force -AsJob
+```
+
+## Next steps
+
+With ASO configured, you can start creating Azure resources using Kubernetes manifests. ASO supports a wide range of Azure services — explore the full list at [azure.github.io/azure-service-operator](https://azure.github.io/azure-service-operator/).


### PR DESCRIPTION
## Why

The repo already has a Crossplane quickstart that lets you stand up an AKS Automatic cluster and manage Azure resources via Kubernetes CRDs. This PR adds an equivalent quickstart for Azure Service Operator (ASO) v2 -- the Microsoft-native alternative -- so both tools can be explored and compared side-by-side.

## What

New `AzureServiceOperator/` directory that follows the same structure and UX as `Crossplane/`:

- **`Deploy.ps1`** -- one-command bootstrap with the same flags (`-StorageAccountName`, `-SkipInfrastructure`, `-Cleanup`) and a deployment context file so cleanup always finds the right resource group
- **`infrastructure/`** -- three Bicep files: AKS Automatic cluster, user-assigned managed identity with federated credential for ASO's operator service account (`azureserviceoperator-system/azureserviceoperator-default`), and an orchestrator
- **`kubernetes/aso-values.yaml`** -- Helm values (with angle-bracket placeholders) enabling Workload Identity auth (`azureTenantID`, `azureSubscriptionID`, `azureClientID`, `useWorkloadIdentityAuth: true`)
- **`kubernetes/examples/storage-account.yaml`** -- ASO v2 `StorageAccount` CR (`storage.azure.com/v1api20230101`) to verify the end-to-end setup
- **`readme.md`** -- quick start, manual reference steps, placeholder table, and cleanup instructions

## Key differences from the Crossplane quickstart

| | Crossplane | ASO |
|---|---|---|
| Install | Helm + several kubectl manifests | Helm only |
| Identity SA | `crossplane-system/provider-azure` | `azureserviceoperator-system/azureserviceoperator-default` |
| Default resource group | `rg-crossplane` | `rg-aso` |
| Example CRD | `storage.azure.upbound.io` | `storage.azure.com` |
| "Wait for providers" step | Yes | No -- ASO is self-contained |

## Notes

- The `ValidatingAdmissionPolicyBinding` workaround from the Crossplane quickstart is included as a precaution; ASO may or may not hit it on AKS Automatic but the delete is idempotent.
- ASO identity gets Contributor on the resource group only -- same scope as Crossplane.