### PR TITLE
fix: ASO quickstart deploy fixes for AKS Automatic

### DIFF
--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -399,7 +399,7 @@ try {
     # This prevents AKS Gatekeeper from seeing stale services with the same selector.
     $HelmStatus = helm status aso --namespace azureserviceoperator-system 2>$null
     if ($LASTEXITCODE -eq 0) {
-        Write-Verbose 'Existing ASO Helm release found — uninstalling...'
+        Write-Verbose "Existing ASO Helm release found — uninstalling. Helm status output: $($HelmStatus -join [Environment]::NewLine)"
         helm uninstall aso --namespace azureserviceoperator-system --wait
         Assert-ExitCode 'helm uninstall aso failed.'
         Write-Verbose 'Helm release uninstalled.'
@@ -460,15 +460,16 @@ try {
     # AKS Automatic. The constraint name includes a hash suffix, so discover it dynamically.
     # AKS will recreate the constraint automatically on its next reconciliation cycle.
     Write-Verbose 'Checking for unique-service-selector Gatekeeper constraints...'
-    $UniqueServiceConstraint = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
-    if ($LASTEXITCODE -eq 0 -and $UniqueServiceConstraint) {
+    $UniqueServiceConstraintRaw = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
+    $UniqueServiceConstraint = if ($null -ne $UniqueServiceConstraintRaw) { $UniqueServiceConstraintRaw.Trim() } else { $null }
+    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($UniqueServiceConstraint)) {
         Write-Verbose "Removing Gatekeeper constraint '$UniqueServiceConstraint' before Helm install..."
-        kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint 2>$null
+        kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 2>$null
         Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
-        Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint'."
+        Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint' or it no longer existed."
     }
     else {
-        Write-Verbose 'No unique-service-selector constraint found — continuing.'
+        Write-Verbose 'No valid unique-service-selector constraint found — continuing.'
     }
 
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -392,7 +392,8 @@ try {
     $HelmStatus = helm status aso --namespace azureserviceoperator-system 2>$null
     if ($LASTEXITCODE -eq 0) {
         Write-Verbose 'Existing ASO Helm release found — uninstalling...'
-        helm uninstall aso --namespace azureserviceoperator-system --wait 2>$null
+        helm uninstall aso --namespace azureserviceoperator-system --wait
+        Assert-ExitCode 'helm uninstall aso failed.'
         Write-Verbose 'Helm release uninstalled.'
     }
 
@@ -438,18 +439,22 @@ catch {
 try {
     Write-Verbose 'Installing ASO via Helm...'
 
-    # Temporarily remove the Gatekeeper constraint that blocks two services with the same
-    # selector in one namespace. ASO's webhook and metrics services both select
-    # 'control-plane: controller-manager', which triggers this policy on AKS Automatic.
-    # AKS will recreate the constraint automatically on its next reconciliation cycle.
-    Write-Verbose 'Removing unique-service-selector Gatekeeper constraint for install...'
-    $UniqueServiceConstraint = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
-    if ($LASTEXITCODE -eq 0 -and $UniqueServiceConstraint) {
+    # Temporarily remove the AKS-managed Gatekeeper constraint that blocks two services
+    # with the same selector in one namespace. ASO's webhook and metrics services both
+    # select 'control-plane: controller-manager', which triggers this policy on
+    # AKS Automatic. To avoid deleting a user-managed policy, only target the known
+    # AKS-managed constraint by its exact name.
+    $UniqueServiceConstraint = 'azurepolicy-k8sazurev1uniqueserviceselector'
+    Write-Verbose "Checking for AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint'..."
+    kubectl get k8sazurev1uniqueserviceselector $UniqueServiceConstraint 1>$null 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Verbose "Removing AKS-managed Gatekeeper constraint '$UniqueServiceConstraint' for install..."
         kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 2>$null
+        Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
         Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint'."
     }
     else {
-        Write-Verbose 'No unique-service-selector constraint found — continuing.'
+        Write-Verbose "AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint' not found — continuing."
     }
 
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -386,6 +386,23 @@ Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 6 of 6 — Install
 Write-Verbose 'Installing Azure Service Operator...'
 
 try {
+    # Delete the namespace if it already exists to avoid AKS Gatekeeper policy violations
+    # caused by stale resources from a previous failed install (e.g. duplicate service selectors).
+    $NsExists = kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null
+    if ($NsExists) {
+        Write-Verbose 'Existing azureserviceoperator-system namespace found — removing to ensure clean install...'
+        kubectl delete namespace azureserviceoperator-system
+        Assert-ExitCode 'kubectl delete namespace azureserviceoperator-system failed.'
+        kubectl wait --for=delete namespace/azureserviceoperator-system --timeout=120s 2>$null
+        Write-Verbose 'Namespace removed.'
+    }
+}
+catch {
+    Write-Verbose "Failed to clean up existing ASO namespace: $($_.Exception.Message)"
+    throw
+}
+
+try {
     Write-Verbose 'Adding ASO Helm repo...'
     helm repo add asohelmchart https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts --force-update | Out-Null
     Assert-ExitCode 'helm repo add failed.'

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -354,8 +354,16 @@ Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 5 of 6 — Install
 Write-Verbose 'Installing cert-manager...'
 
 # Remove the ValidatingAdmissionPolicy binding that blocks webhook installs on AKS Automatic
-kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found 2>$null
-# Intentionally not checking exit code — binding may already be absent
+try {
+    Write-Verbose 'Removing AKS-managed ValidatingAdmissionPolicy binding if it exists...'
+    kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found 2>$null
+    Assert-ExitCode 'kubectl delete validatingadmissionpolicybinding failed.'
+    Write-Verbose 'AKS-managed ValidatingAdmissionPolicy binding removal completed.'
+}
+catch {
+    Write-Verbose "Failed to remove AKS-managed ValidatingAdmissionPolicy binding: $($_.Exception.Message)"
+    throw
+}
 
 try {
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
@@ -452,17 +460,10 @@ try {
     # AKS Automatic. To avoid deleting a user-managed policy, only target the known
     # AKS-managed constraint by its exact name.
     $UniqueServiceConstraint = 'azurepolicy-k8sazurev1uniqueserviceselector'
-    Write-Verbose "Checking for AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint'..."
-    kubectl get k8sazurev1uniqueserviceselector $UniqueServiceConstraint 1>$null 2>$null
-    if ($LASTEXITCODE -eq 0) {
-        Write-Verbose "Removing AKS-managed Gatekeeper constraint '$UniqueServiceConstraint' for install..."
-        kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 2>$null
-        Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
-        Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint'."
-    }
-    else {
-        Write-Verbose "AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint' not found — continuing."
-    }
+    Write-Verbose "Ensuring AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint' is absent before install..."
+    kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 1>$null
+    Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
+    Write-Verbose "Confirmed Gatekeeper constraint '$UniqueServiceConstraint' is absent or removed."
 
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
     helm upgrade aso asohelmchart/azure-service-operator `

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -459,17 +459,29 @@ try {
     # select 'control-plane: controller-manager', which triggers this policy on
     # AKS Automatic. The constraint name includes a hash suffix, so discover it dynamically.
     # AKS will recreate the constraint automatically on its next reconciliation cycle.
+    # stderr is merged into the output (2>&1) so connectivity/auth failures are captured
+    # and can be distinguished from a benign "CRD not registered on this cluster" result.
     Write-Verbose 'Checking for unique-service-selector Gatekeeper constraints...'
-    $UniqueServiceConstraintRaw = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
-    $UniqueServiceConstraint = if ($null -ne $UniqueServiceConstraintRaw) { $UniqueServiceConstraintRaw.Trim() } else { $null }
-    if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($UniqueServiceConstraint)) {
+    $UniqueServiceConstraintRaw = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>&1
+    $UniqueServiceConstraint = ($UniqueServiceConstraintRaw | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0) {
+        Write-Verbose "kubectl get k8sazurev1uniqueserviceselector returned exit code $LASTEXITCODE — checking error type..."
+        if ($UniqueServiceConstraint -like "*the server doesn't have a resource type*") {
+            # The CRD is not registered on this cluster (non-AKS Automatic) — safe to skip.
+            Write-Verbose 'k8sazurev1uniqueserviceselector CRD not present on this cluster — skipping constraint removal.'
+        }
+        else {
+            throw "kubectl get k8sazurev1uniqueserviceselector failed: $UniqueServiceConstraint"
+        }
+    }
+    elseif (-not [string]::IsNullOrWhiteSpace($UniqueServiceConstraint)) {
         Write-Verbose "Removing Gatekeeper constraint '$UniqueServiceConstraint' before Helm install..."
         kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 2>$null
         Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
         Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint' or it no longer existed."
     }
     else {
-        Write-Verbose 'No valid unique-service-selector constraint found — continuing.'
+        Write-Verbose 'No unique-service-selector constraints found — continuing.'
     }
 
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -398,6 +398,7 @@ try {
     }
 
     $NsExists = kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null
+    Assert-ExitCode 'kubectl get namespace azureserviceoperator-system failed.'
     if ($NsExists) {
         Write-Verbose 'Removing azureserviceoperator-system namespace...'
         kubectl delete namespace azureserviceoperator-system --ignore-not-found
@@ -406,12 +407,18 @@ try {
         # Poll until the namespace is fully gone — kubectl wait --for=delete can return
         # while the namespace is still in Terminating state, which causes Gatekeeper to
         # still see the old services and block the new install.
+        # $LASTEXITCODE is checked after each kubectl call so connectivity/auth failures
+        # are not silently misread as "namespace gone".
         $Deadline = (Get-Date).AddSeconds(180)
-        while ((kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null) -and (Get-Date) -lt $Deadline) {
-            Write-Verbose 'Waiting for namespace azureserviceoperator-system to finish terminating...'
-            Start-Sleep -Seconds 5
-        }
-        if (kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null) {
+        do {
+            $NsStillExists = kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null
+            Assert-ExitCode 'kubectl get namespace azureserviceoperator-system failed during termination wait.'
+            if ($NsStillExists) {
+                Write-Verbose 'Waiting for namespace azureserviceoperator-system to finish terminating...'
+                Start-Sleep -Seconds 5
+            }
+        } while ($NsStillExists -and (Get-Date) -lt $Deadline)
+        if ($NsStillExists) {
             throw 'Namespace azureserviceoperator-system did not terminate within 180 seconds.'
         }
         Write-Verbose 'Namespace fully removed.'

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -386,15 +386,34 @@ Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 6 of 6 — Install
 Write-Verbose 'Installing Azure Service Operator...'
 
 try {
-    # Delete the namespace if it already exists to avoid AKS Gatekeeper policy violations
-    # caused by stale resources from a previous failed install (e.g. duplicate service selectors).
+    # Uninstall existing Helm release first (cleanest way to remove all Helm-managed resources),
+    # then delete the namespace and poll until it is fully gone — not just "Terminating".
+    # This prevents AKS Gatekeeper from seeing stale services with the same selector.
+    $HelmStatus = helm status aso --namespace azureserviceoperator-system 2>$null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Verbose 'Existing ASO Helm release found — uninstalling...'
+        helm uninstall aso --namespace azureserviceoperator-system --wait 2>$null
+        Write-Verbose 'Helm release uninstalled.'
+    }
+
     $NsExists = kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null
     if ($NsExists) {
-        Write-Verbose 'Existing azureserviceoperator-system namespace found — removing to ensure clean install...'
-        kubectl delete namespace azureserviceoperator-system
+        Write-Verbose 'Removing azureserviceoperator-system namespace...'
+        kubectl delete namespace azureserviceoperator-system --ignore-not-found
         Assert-ExitCode 'kubectl delete namespace azureserviceoperator-system failed.'
-        kubectl wait --for=delete namespace/azureserviceoperator-system --timeout=120s 2>$null
-        Write-Verbose 'Namespace removed.'
+
+        # Poll until the namespace is fully gone — kubectl wait --for=delete can return
+        # while the namespace is still in Terminating state, which causes Gatekeeper to
+        # still see the old services and block the new install.
+        $Deadline = (Get-Date).AddSeconds(180)
+        while ((kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null) -and (Get-Date) -lt $Deadline) {
+            Write-Verbose 'Waiting for namespace azureserviceoperator-system to finish terminating...'
+            Start-Sleep -Seconds 5
+        }
+        if (kubectl get namespace azureserviceoperator-system --ignore-not-found 2>$null) {
+            throw 'Namespace azureserviceoperator-system did not terminate within 180 seconds.'
+        }
+        Write-Verbose 'Namespace fully removed.'
     }
 }
 catch {
@@ -424,6 +443,7 @@ try {
         --namespace azureserviceoperator-system `
         --create-namespace `
         --values "$GeneratedDir/aso-values.yaml" `
+        --cleanup-on-fail `
         --wait
     Assert-ExitCode 'helm upgrade/install aso failed.'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Completed -ErrorAction SilentlyContinue

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -159,7 +159,7 @@ function Assert-ExitCode {
 
 #region Part 1 - Deploying infrastructure
 
-Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 1 of 5 — Deploying infrastructure' -PercentComplete 0 -ErrorAction SilentlyContinue
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 1 of 6 — Deploying infrastructure' -PercentComplete 0 -ErrorAction SilentlyContinue
 
 if (-not $SkipInfrastructure) {
     Write-Verbose 'Deploying infrastructure...'
@@ -235,7 +235,7 @@ else {
 
 #region Part 2 - Capturing deployment outputs
 
-Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 2 of 5 — Capturing deployment outputs' -PercentComplete 20 -ErrorAction SilentlyContinue
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 2 of 6 — Capturing deployment outputs' -PercentComplete 15 -ErrorAction SilentlyContinue
 Write-Verbose 'Capturing deployment outputs...'
 
 try {
@@ -273,7 +273,7 @@ Write-Verbose "Tenant:         $TenantId"
 
 #region Part 3 - Generating YAML manifests
 
-Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 3 of 5 — Generating YAML manifests' -PercentComplete 40 -ErrorAction SilentlyContinue
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 3 of 6 — Generating YAML manifests' -PercentComplete 30 -ErrorAction SilentlyContinue
 Write-Verbose 'Generating YAML manifests...'
 
 $DeploymentContextFileName = 'deployment-context.json'
@@ -317,7 +317,7 @@ Write-Verbose "Generated manifests in $GeneratedDir"
 
 #region Part 4 - Connecting to cluster
 
-Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 4 of 5 — Connecting to cluster' -PercentComplete 60 -ErrorAction SilentlyContinue
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 4 of 6 — Connecting to cluster' -PercentComplete 50 -ErrorAction SilentlyContinue
 Write-Verbose 'Connecting to cluster...'
 
 try {
@@ -342,17 +342,48 @@ catch {
 #endregion Part 4 - Connecting to cluster
 
 ########################################################################
-#              Part 5 - Installing ASO                                 #
+#              Part 5 - Installing cert-manager                        #
 ########################################################################
 
-#region Part 5 - Installing ASO
+#region Part 5 - Installing cert-manager
 
-Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 5 of 5 — Installing Azure Service Operator' -PercentComplete 80 -ErrorAction SilentlyContinue
-Write-Verbose 'Installing Azure Service Operator...'
+# cert-manager is a hard prerequisite for ASO v2 — ASO uses it for webhook
+# TLS certificates. It must be running before the ASO Helm install.
 
-# Remove the ValidatingAdmissionPolicy binding that may conflict with ASO webhooks on AKS Automatic
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 5 of 6 — Installing cert-manager' -PercentComplete 80 -ErrorAction SilentlyContinue
+Write-Verbose 'Installing cert-manager...'
+
+# Remove the ValidatingAdmissionPolicy binding that blocks webhook installs on AKS Automatic
 kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found 2>$null
 # Intentionally not checking exit code — binding may already be absent
+
+try {
+    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+    Assert-ExitCode 'kubectl apply cert-manager failed.'
+
+    Write-Verbose 'Waiting for cert-manager deployments to become available...'
+    kubectl wait deployment cert-manager cert-manager-cainjector cert-manager-webhook `
+        --for=condition=Available `
+        --namespace cert-manager `
+        --timeout=300s
+    Assert-ExitCode 'cert-manager deployments did not become available in time.'
+    Write-Verbose 'cert-manager ready.'
+}
+catch {
+    Write-Verbose "cert-manager install failed: $($_.Exception.Message)"
+    throw
+}
+
+#endregion Part 5 - Installing cert-manager
+
+########################################################################
+#              Part 6 - Installing ASO                                 #
+########################################################################
+
+#region Part 6 - Installing ASO
+
+Write-Progress -Id 0 -Activity 'ASO deployment' -Status 'Part 6 of 6 — Installing Azure Service Operator' -PercentComplete 90 -ErrorAction SilentlyContinue
+Write-Verbose 'Installing Azure Service Operator...'
 
 try {
     Write-Verbose 'Adding ASO Helm repo...'
@@ -371,7 +402,7 @@ catch {
 try {
     Write-Verbose 'Installing ASO via Helm...'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
-    helm upgrade aso asohelmchart/aso-helm-chart `
+    helm upgrade aso asohelmchart/azure-service-operator `
         --install `
         --namespace azureserviceoperator-system `
         --create-namespace `
@@ -388,7 +419,7 @@ catch {
 
 Write-Progress -Id 0 -Activity 'ASO deployment' -Completed -ErrorAction SilentlyContinue
 
-#endregion Part 5 - Installing ASO
+#endregion Part 6 - Installing ASO
 
 Write-Verbose "All done. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
 

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -437,6 +437,21 @@ catch {
 
 try {
     Write-Verbose 'Installing ASO via Helm...'
+
+    # Temporarily remove the Gatekeeper constraint that blocks two services with the same
+    # selector in one namespace. ASO's webhook and metrics services both select
+    # 'control-plane: controller-manager', which triggers this policy on AKS Automatic.
+    # AKS will recreate the constraint automatically on its next reconciliation cycle.
+    Write-Verbose 'Removing unique-service-selector Gatekeeper constraint for install...'
+    $UniqueServiceConstraint = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and $UniqueServiceConstraint) {
+        kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 2>$null
+        Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint'."
+    }
+    else {
+        Write-Verbose 'No unique-service-selector constraint found — continuing.'
+    }
+
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
     helm upgrade aso asohelmchart/azure-service-operator `
         --install `

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -477,7 +477,8 @@ Write-Verbose "All done. Elapsed time: $($ElapsedTime.Elapsed.ToString())."
 
 Write-Host ''
 Write-Host 'Azure Service Operator is ready. To test with a Storage Account:' -ForegroundColor Green
-Write-Host "  kubectl apply -f $GeneratedDir/examples/storage-account.yaml"
+$ExampleFile = Join-Path $GeneratedDir 'examples' 'storage-account.yaml'
+Write-Host "  kubectl apply -f $ExampleFile"
 Write-Host '  kubectl get storageaccount -w'
 Write-Host ''
 Write-Host 'To clean up everything:'

--- a/AzureServiceOperator/Deploy.ps1
+++ b/AzureServiceOperator/Deploy.ps1
@@ -457,13 +457,19 @@ try {
     # Temporarily remove the AKS-managed Gatekeeper constraint that blocks two services
     # with the same selector in one namespace. ASO's webhook and metrics services both
     # select 'control-plane: controller-manager', which triggers this policy on
-    # AKS Automatic. To avoid deleting a user-managed policy, only target the known
-    # AKS-managed constraint by its exact name.
-    $UniqueServiceConstraint = 'azurepolicy-k8sazurev1uniqueserviceselector'
-    Write-Verbose "Ensuring AKS-managed unique-service-selector Gatekeeper constraint '$UniqueServiceConstraint' is absent before install..."
-    kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint --ignore-not-found 1>$null
-    Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
-    Write-Verbose "Confirmed Gatekeeper constraint '$UniqueServiceConstraint' is absent or removed."
+    # AKS Automatic. The constraint name includes a hash suffix, so discover it dynamically.
+    # AKS will recreate the constraint automatically on its next reconciliation cycle.
+    Write-Verbose 'Checking for unique-service-selector Gatekeeper constraints...'
+    $UniqueServiceConstraint = kubectl get k8sazurev1uniqueserviceselector -o jsonpath='{.items[0].metadata.name}' 2>$null
+    if ($LASTEXITCODE -eq 0 -and $UniqueServiceConstraint) {
+        Write-Verbose "Removing Gatekeeper constraint '$UniqueServiceConstraint' before Helm install..."
+        kubectl delete k8sazurev1uniqueserviceselector $UniqueServiceConstraint 2>$null
+        Assert-ExitCode "Failed to remove Gatekeeper constraint '$UniqueServiceConstraint'."
+        Write-Verbose "Removed Gatekeeper constraint '$UniqueServiceConstraint'."
+    }
+    else {
+        Write-Verbose 'No unique-service-selector constraint found — continuing.'
+    }
 
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing ASO chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
     helm upgrade aso asohelmchart/azure-service-operator `

--- a/AzureServiceOperator/kubernetes/aso-values.yaml
+++ b/AzureServiceOperator/kubernetes/aso-values.yaml
@@ -9,3 +9,9 @@ useWorkloadIdentityAuth: true
 # Install only Storage CRDs. Use '*' for all, but avoid it on small clusters
 # as it installs hundreds of CRDs. Extend this pattern to add more services.
 crdPattern: "storage.azure.com/*"
+
+# Disable the metrics service. AKS Automatic's Gatekeeper policy blocks two
+# services in the same namespace sharing a selector, and both the webhook
+# service and the metrics service select 'control-plane: controller-manager'.
+metrics:
+  enable: false

--- a/AzureServiceOperator/kubernetes/aso-values.yaml
+++ b/AzureServiceOperator/kubernetes/aso-values.yaml
@@ -9,9 +9,3 @@ useWorkloadIdentityAuth: true
 # Install only Storage CRDs. Use '*' for all, but avoid it on small clusters
 # as it installs hundreds of CRDs. Extend this pattern to add more services.
 crdPattern: "storage.azure.com/*"
-
-# Disable the metrics service. AKS Automatic's Gatekeeper policy blocks two
-# services in the same namespace sharing a selector, and both the webhook
-# service and the metrics service select 'control-plane: controller-manager'.
-metrics:
-  enable: false

--- a/AzureServiceOperator/kubernetes/aso-values.yaml
+++ b/AzureServiceOperator/kubernetes/aso-values.yaml
@@ -1,8 +1,11 @@
 # Helm values for Azure Service Operator v2
-# Tested with ASO v2 (asohelmchart/aso-helm-chart)
 # Workload Identity authentication — no secrets stored in the cluster
 
 azureTenantID: "<TENANT_ID>"
 azureSubscriptionID: "<SUBSCRIPTION_ID>"
 azureClientID: "<ASO_IDENTITY_CLIENT_ID>"
 useWorkloadIdentityAuth: true
+
+# Install only Storage CRDs. Use '*' for all, but avoid it on small clusters
+# as it installs hundreds of CRDs. Extend this pattern to add more services.
+crdPattern: "storage.azure.com/*"

--- a/AzureServiceOperator/readme.md
+++ b/AzureServiceOperator/readme.md
@@ -28,6 +28,7 @@ AzureServiceOperator/
 - Contributor role assignment on the resource group
 
 **Kubernetes (Helm + YAML manifests):**
+- cert-manager v1.17.2 (required by ASO for webhook TLS certificates)
 - Azure Service Operator v2 (via Helm), configured with Azure Workload Identity
 
 ## Prerequisites
@@ -49,7 +50,8 @@ cd AzureServiceOperator
 The script deploys the following end to end:
 
 1. **Azure infrastructure** (via Bicep) — AKS Automatic cluster, managed identity, and federated credential
-2. **Azure Service Operator** (via Helm) — installed into the `azureserviceoperator-system` namespace, configured with Workload Identity
+2. **cert-manager** — required by ASO for webhook TLS certificates
+3. **Azure Service Operator** (via Helm) — installed into the `azureserviceoperator-system` namespace, configured with Workload Identity
 
 When the script finishes, ASO is fully operational and ready to manage Azure resources. The `-StorageAccountName` value is pre-filled into the example manifest so you can immediately try it out:
 
@@ -141,7 +143,25 @@ kubelogin convert-kubeconfig -l azurecli
 
 > **Note:** AKS Automatic uses Entra ID authentication. The `kubelogin convert-kubeconfig -l azurecli` command configures kubectl to reuse your existing `az login` session, which avoids Conditional Access issues with interactive browser sign-in.
 
-## 4. Install Azure Service Operator
+## 4. Install cert-manager
+
+cert-manager is a hard prerequisite for ASO v2 — ASO uses it for webhook TLS certificates.
+
+```powershell
+# Remove the ValidatingAdmissionPolicy binding that may block webhook installs on AKS Automatic
+kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found
+
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+
+kubectl wait deployment cert-manager cert-manager-cainjector cert-manager-webhook `
+  --for=condition=Available `
+  --namespace cert-manager `
+  --timeout=300s
+```
+
+> **Note:** AKS will automatically recreate the `ValidatingAdmissionPolicyBinding` after a reconciliation cycle.
+
+## 5. Install Azure Service Operator
 
 ASO is installed as a single Helm chart. The Workload Identity configuration is passed via the values file.
 
@@ -149,7 +169,7 @@ ASO is installed as a single Helm chart. The Workload Identity configuration is 
 helm repo add asohelmchart https://raw.githubusercontent.com/Azure/azure-service-operator/main/v2/charts
 helm repo update
 
-helm upgrade aso asohelmchart/aso-helm-chart `
+helm upgrade aso asohelmchart/azure-service-operator `
   --install `
   --namespace azureserviceoperator-system `
   --create-namespace `
@@ -157,19 +177,13 @@ helm upgrade aso asohelmchart/aso-helm-chart `
   --wait
 ```
 
-> **Note:** If the install fails on AKS Automatic with a webhook or RBAC error, try removing the built-in `ValidatingAdmissionPolicyBinding` that blocks certain cluster-level operations before retrying:
-> ```powershell
-> kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found
-> ```
-> AKS will automatically recreate this binding after a reconciliation cycle.
-
 Wait for ASO pods to be ready:
 
 ```powershell
 kubectl get pods -n azureserviceoperator-system -w
 ```
 
-## 5. Verify
+## 6. Verify
 
 ```powershell
 # ASO manager pod should be Running
@@ -179,7 +193,7 @@ kubectl get pods -n azureserviceoperator-system
 kubectl logs -n azureserviceoperator-system -l control-plane=controller-manager --tail=20
 ```
 
-## 6. Try it out — create a Storage Account
+## 7. Try it out — create a Storage Account
 
 ```powershell
 kubectl apply -f kubernetes/examples/storage-account.yaml


### PR DESCRIPTION
The ASO quickstart merged in #7 failed on AKS Automatic clusters due to several issues discovered during testing. This PR fixes all of them.

## What changed

- **cert-manager prerequisite** -- ASO v2 requires cert-manager for webhook TLS. Added it as a new deployment step (Part 5) with `kubectl wait` for readiness before proceeding.
- **Helm chart name and crdPattern** -- Fixed the chart name from `aso-helm-chart` to `azure-service-operator` and added the required `crdPattern` value (ASO installs zero CRDs by default).
- **AKS Automatic policy workarounds** -- AKS Automatic's deployment safeguards block webhook installs and duplicate service selectors. The script now deletes the `ValidatingAdmissionPolicyBinding` before cert-manager and the `k8sazurev1uniqueserviceselector` Gatekeeper constraint before the ASO Helm install. AKS recreates both automatically.
- **Robust namespace cleanup** -- Replaced `kubectl wait --for=delete` with a polling loop, since the wait command can return while the namespace is still terminating. Also added `helm uninstall` before namespace deletion and `--cleanup-on-fail` on the Helm upgrade.
- **Clean output paths** -- The success message now uses `Join-Path` for cross-platform path separators instead of mixing `\` and `/`.

## Documentation

Updated `readme.md` to reflect the cert-manager step, correct chart name, and adjusted step numbering (now 7 steps).

Fixes issues found while testing #7.