### PR TITLE
feat: add Foundry Local demo with Open WebUI chat interface

### DIFF
--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -76,7 +76,7 @@ If the model dropdown is empty, add a Direct Connection manually:
 
 1. Open **Settings** → **Connections** → **Manage Direct Connections**
 2. Click **+**
-3. Set **URL** to `http://host.docker.internal:<PORT>/v1` (get the port from `foundry service status`)
+3. Set **URL** to match the scheme and port reported by `foundry service status`, using `host.docker.internal` as the host and appending `/v1` (for example, `http://host.docker.internal:<PORT>/v1` or `https://host.docker.internal:<PORT>/v1`)
 4. Set **Auth** to **None**
 5. Click **Save**
 

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -49,7 +49,6 @@ foundry model list
 | `-Model` | `qwen2.5-0.5b` | Model alias to load |
 | `-OpenWebUIPort` | `3000` | Local port for the web UI |
 | `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
-| `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
 | `-Cleanup` | — | Stop and remove the local demo resources created by the script |
 
 ### Examples

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -92,21 +92,10 @@ foundry service ps
 
 ## Cleanup
 
-Stop and remove everything:
+Use the `-Cleanup` switch to stop and remove everything:
 
 ```powershell
-# Stop Open WebUI
-docker rm -f open-webui-foundry
-
-# Remove the persistent volume (deletes chat history)
-docker volume rm open-webui-foundry
-
-# Stop Foundry Local service
-foundry service stop
-
-# (Optional) Remove cached models
-foundry cache list
-foundry cache remove <model-id>
+.\deploy.ps1 -Cleanup
 ```
 
 ## How It Works

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -49,7 +49,8 @@ foundry model list
 | `-Model` | `qwen2.5-0.5b` | Model alias to load |
 | `-OpenWebUIPort` | `3000` | Local port for the web UI |
 | `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
-| `-Verbose` | — | Show detailed progress messages |
+| `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
+| `-Cleanup` | — | Stop and remove the local demo resources created by the script |
 
 ### Examples
 

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -9,8 +9,9 @@ This demo uses [Microsoft Foundry Local](https://learn.microsoft.com/en-us/azure
 | Requirement | Windows | macOS |
 |---|---|---|
 | **PowerShell 7+** | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos) |
+| **Package manager** | `winget` ([Install](https://learn.microsoft.com/en-us/windows/package-manager/winget/)) | Homebrew `brew` ([Install](https://brew.sh/)) |
 
-> **Note:** Foundry Local and Docker Desktop (when needed) are installed automatically by the script (`winget` on Windows, `brew` on macOS).
+> **Note:** Foundry Local and Docker Desktop (when needed) are installed automatically by the script using `winget` on Windows and `brew` on macOS. Install the required package manager first if it isn't already available.
 
 ## Quick Start
 
@@ -25,6 +26,8 @@ That's it. The script will:
 3. Download and load the default model (`qwen2.5-0.5b`, ~500M params)
 4. Launch Open WebUI in a Docker container
 5. Open your browser to <http://localhost:3000>
+
+> **Security note:** Open WebUI runs without authentication (`WEBUI_AUTH=False`) for demo simplicity. Only run this on a trusted machine and network — do not expose the port to untrusted networks.
 
 ## Using a Different Model
 

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -1,0 +1,138 @@
+# Foundry Local + Open WebUI Demo
+
+Run AI models locally on your device with a browser-based chat interface — no cloud, no API keys, no subscriptions.
+
+This demo uses [Microsoft Foundry Local](https://learn.microsoft.com/en-us/azure/foundry-local/what-is-foundry-local) as the local AI runtime and [Open WebUI](https://docs.openwebui.com/) as the chat interface.
+
+## Prerequisites
+
+| Requirement | Windows | macOS |
+|---|---|---|
+| **PowerShell 7+** | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos) |
+| **Docker Desktop** | [Install](https://docs.docker.com/desktop/setup/install/windows-install/) | [Install](https://docs.docker.com/desktop/setup/install/mac-install/) |
+
+> **Note:** Foundry Local CLI is installed automatically by the script (`winget` on Windows, `brew` on macOS).
+
+## Quick Start
+
+```powershell
+.\deploy.ps1
+```
+
+That's it. The script will:
+
+1. Install Foundry Local CLI (if not already installed)
+2. Start the Foundry Local service
+3. Download and load the default model (`qwen2.5-0.5b`, ~500M params)
+4. Launch Open WebUI in a Docker container
+5. Open your browser to <http://localhost:3000>
+
+## Using a Different Model
+
+Specify a model alias with the `-Model` parameter:
+
+```powershell
+.\deploy.ps1 -Model phi-4-mini
+.\deploy.ps1 -Model phi-3.5-mini
+.\deploy.ps1 -Model deepseek-r1-7b
+```
+
+To see all available models:
+
+```powershell
+foundry model list
+```
+
+## Options
+
+| Parameter | Default | Description |
+|---|---|---|
+| `-Model` | `qwen2.5-0.5b` | Model alias to load |
+| `-OpenWebUIPort` | `3000` | Local port for the web UI |
+| `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
+| `-Verbose` | — | Show detailed progress messages |
+
+### Examples
+
+```powershell
+# Use verbose output to see what's happening
+.\deploy.ps1 -Verbose
+
+# Run on a custom port
+.\deploy.ps1 -OpenWebUIPort 8080
+
+# Only start Foundry Local without the web UI
+.\deploy.ps1 -SkipOpenWebUI
+```
+
+## Troubleshooting
+
+### Models don't appear in Open WebUI
+
+If the model dropdown is empty, add a Direct Connection manually:
+
+1. Open **Settings** → **Connections** → **Manage Direct Connections**
+2. Click **+**
+3. Set **URL** to `http://host.docker.internal:<PORT>/v1` (get the port from `foundry service status`)
+4. Set **Auth** to **None**
+5. Click **Save**
+
+### Foundry Local service errors
+
+```powershell
+foundry service restart
+foundry service status
+```
+
+### Check loaded models
+
+```powershell
+foundry service ps
+```
+
+## Cleanup
+
+Stop and remove everything:
+
+```powershell
+# Stop Open WebUI
+docker rm -f open-webui-foundry
+
+# Remove the persistent volume (deletes chat history)
+docker volume rm open-webui-foundry
+
+# Stop Foundry Local service
+foundry service stop
+
+# (Optional) Remove cached models
+foundry cache list
+foundry cache remove <model-id>
+```
+
+## How It Works
+
+```
+┌─────────────────────┐     ┌──────────────────────────┐
+│                     │     │                          │
+│   Open WebUI        │────▶│   Foundry Local Service  │
+│   (Docker, :3000)   │     │   (host, dynamic port)   │
+│                     │     │                          │
+│   Browser chat UI   │     │   OpenAI-compatible API  │
+│                     │     │   Model inference (ONNX) │
+└─────────────────────┘     └──────────────────────────┘
+        ▲                              │
+        │                              ▼
+   You (browser)              Local AI model
+                              (qwen2.5-0.5b, etc.)
+```
+
+- **Foundry Local** handles model management, hardware acceleration (GPU/NPU/CPU), and serves an OpenAI-compatible API
+- **Open WebUI** provides a polished chat interface that connects to the Foundry Local API
+- All data stays on your device — nothing is sent to the cloud
+
+## Links
+
+- [Foundry Local Documentation](https://learn.microsoft.com/en-us/azure/foundry-local/)
+- [Foundry Local GitHub](https://github.com/microsoft/Foundry-Local)
+- [Open WebUI Documentation](https://docs.openwebui.com/)
+- [Foundry Local CLI Reference](https://learn.microsoft.com/en-us/azure/foundry-local/reference/reference-cli)

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -53,6 +53,7 @@ foundry model list
 | `-OpenWebUIPort` | `3000` | Local port for the web UI |
 | `-SkipOpenWebUI` | — | Only start Foundry Local (no web UI) |
 | `-Cleanup` | — | Stop and remove the local demo resources created by the script |
+| `-Force` | — | Skip all confirmation prompts during cleanup |
 
 ### Examples
 
@@ -97,7 +98,11 @@ foundry service ps
 Use the `-Cleanup` switch to stop and remove everything:
 
 ```powershell
+# Interactive cleanup (prompts for each component)
 .\deploy.ps1 -Cleanup
+
+# Remove everything without prompts
+.\deploy.ps1 -Cleanup -Force
 ```
 
 ## How It Works
@@ -120,6 +125,8 @@ Use the `-Cleanup` switch to stop and remove everything:
 - **Foundry Local** handles model management, hardware acceleration (GPU/NPU/CPU), and serves an OpenAI-compatible API
 - **Open WebUI** provides a polished chat interface that connects to the Foundry Local API
 - All data stays on your device — nothing is sent to the cloud
+
+> **Note:** The demo disables Open WebUI authentication (`WEBUI_AUTH=False`) for simplicity. Do not expose the web UI to untrusted networks without enabling authentication first.
 
 ## Links
 

--- a/FoundryLocal/README.md
+++ b/FoundryLocal/README.md
@@ -9,9 +9,8 @@ This demo uses [Microsoft Foundry Local](https://learn.microsoft.com/en-us/azure
 | Requirement | Windows | macOS |
 |---|---|---|
 | **PowerShell 7+** | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) | [Install](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-macos) |
-| **Docker Desktop** | [Install](https://docs.docker.com/desktop/setup/install/windows-install/) | [Install](https://docs.docker.com/desktop/setup/install/mac-install/) |
 
-> **Note:** Foundry Local CLI is installed automatically by the script (`winget` on Windows, `brew` on macOS).
+> **Note:** Foundry Local and Docker Desktop (when needed) are installed automatically by the script (`winget` on Windows, `brew` on macOS).
 
 ## Quick Start
 
@@ -21,7 +20,7 @@ This demo uses [Microsoft Foundry Local](https://learn.microsoft.com/en-us/azure
 
 That's it. The script will:
 
-1. Install Foundry Local CLI (if not already installed)
+1. Install Foundry Local (if not already installed)
 2. Start the Foundry Local service
 3. Download and load the default model (`qwen2.5-0.5b`, ~500M params)
 4. Launch Open WebUI in a Docker container

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -78,17 +78,52 @@ Write-Verbose "Running on $Platform."
 # Check Docker (required for Open WebUI)
 if (-not $SkipOpenWebUI) {
     Write-Verbose "Checking for Docker..."
+    $DockerReady = $false
     try {
         $DockerVersion = docker version --format '{{.Server.Version}}' 2>$null
-        if (-not $DockerVersion) {
-            throw "Docker is not running."
+        if ($DockerVersion) {
+            $DockerReady = $true
+            Write-Verbose "Docker version $DockerVersion found."
         }
-        Write-Verbose "Docker version $DockerVersion found."
     }
     catch {
-        Write-Verbose "Docker check failed."
-        Write-Error "Docker Desktop is required for Open WebUI. Install it from https://www.docker.com/products/docker-desktop/ and ensure it is running. Alternatively, use -SkipOpenWebUI to run Foundry Local without the web interface."
-        exit 1
+        Write-Verbose "Docker not found or not running."
+    }
+
+    if (-not $DockerReady) {
+        Write-Host "Docker Desktop is required for Open WebUI but was not detected." -ForegroundColor Yellow
+        $Install = Read-Host "Would you like to install Docker Desktop now? (Y/N)"
+        if ($Install -eq 'Y' -or $Install -eq 'y') {
+            Write-Host "Installing Docker Desktop..." -ForegroundColor Cyan
+            if ($Platform -eq "Windows") {
+                try {
+                    Write-Verbose "Installing Docker Desktop via winget..."
+                    winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
+                    Write-Verbose "Docker Desktop installed via winget."
+                }
+                catch {
+                    Write-Verbose "Docker Desktop winget installation failed: $_"
+                    throw
+                }
+            }
+            elseif ($Platform -eq "macOS") {
+                try {
+                    Write-Verbose "Installing Docker Desktop via Homebrew cask..."
+                    brew install --cask docker
+                    Write-Verbose "Docker Desktop installed via Homebrew."
+                }
+                catch {
+                    Write-Verbose "Docker Desktop Homebrew installation failed: $_"
+                    throw
+                }
+            }
+            Write-Host "Docker Desktop installed. Please launch it and wait for it to start, then re-run this script." -ForegroundColor Yellow
+            exit 0
+        }
+        else {
+            Write-Host "Skipping Docker install. Use -SkipOpenWebUI to run Foundry Local without the web interface." -ForegroundColor DarkGray
+            exit 1
+        }
     }
 }
 

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -102,77 +102,89 @@ if (-not $SkipOpenWebUI) {
     }
 
     if (-not $DockerReady) {
-        Write-Host "Docker Desktop is required for Open WebUI but was not detected." -ForegroundColor Yellow
-        Write-Host "  (If you recently installed Docker, try restarting your terminal first.)" -ForegroundColor DarkGray
-        $Install = Read-Host "Would you like to install Docker Desktop now? (Y/N)"
-        if ($Install -eq 'Y' -or $Install -eq 'y') {
-            Write-Host "Installing Docker Desktop..." -ForegroundColor Cyan
-            if ($Platform -eq "Windows") {
-                try {
-                    Write-Verbose "Installing Docker Desktop via winget..."
-                    winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
-                    Write-Verbose "Docker Desktop installed via winget."
-                }
-                catch {
-                    Write-Verbose "Docker Desktop winget installation failed: $_"
-                    throw
-                }
-            }
-            elseif ($Platform -eq "macOS") {
-                try {
-                    Write-Verbose "Installing Docker Desktop via Homebrew cask..."
-                    brew install --cask docker
-                    Write-Verbose "Docker Desktop installed via Homebrew."
-                }
-                catch {
-                    Write-Verbose "Docker Desktop Homebrew installation failed: $_"
-                    throw
-                }
-            }
-            # Launch Docker Desktop and wait for the engine to be ready
-            Write-Host "Starting Docker Desktop..." -ForegroundColor Cyan
-            if ($Platform -eq "Windows") {
-                $DockerPath = Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
-                if (Test-Path $DockerPath) {
-                    Start-Process $DockerPath
-                } else {
-                    Write-Verbose "Docker Desktop executable not found at expected path, trying shell start..."
-                    Start-Process "Docker Desktop"
-                }
-            }
-            elseif ($Platform -eq "macOS") {
-                open -a Docker
-            }
+        # Distinguish between "not installed" and "installed but not running"
+        $DockerInstalled = [bool]$DockerCmd
 
-            Write-Host "  Waiting for Docker engine to be ready..." -ForegroundColor DarkGray
-            $DockerMaxRetries = 100
-            $DockerRetry = 0
-            while ($DockerRetry -lt $DockerMaxRetries) {
-                try {
-                    $null = docker info 2>&1
-                    if ($LASTEXITCODE -eq 0) {
-                        Write-Verbose "Docker engine is ready."
-                        $DockerReady = $true
-                        break
+        if (-not $DockerInstalled) {
+            # Docker CLI not found — offer to install
+            Write-Host "Docker Desktop is required for Open WebUI but was not detected." -ForegroundColor Yellow
+            Write-Host "  (If you recently installed Docker, try restarting your terminal first.)" -ForegroundColor DarkGray
+            $Install = Read-Host "Would you like to install Docker Desktop now? (Y/N)"
+            if ($Install -eq 'Y' -or $Install -eq 'y') {
+                Write-Host "Installing Docker Desktop..." -ForegroundColor Cyan
+                if ($Platform -eq "Windows") {
+                    try {
+                        Write-Verbose "Installing Docker Desktop via winget..."
+                        winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
+                        Write-Verbose "Docker Desktop installed via winget."
+                    }
+                    catch {
+                        Write-Verbose "Docker Desktop winget installation failed: $_"
+                        throw
                     }
                 }
-                catch {
-                    # Not ready yet
+                elseif ($Platform -eq "macOS") {
+                    try {
+                        Write-Verbose "Installing Docker Desktop via Homebrew cask..."
+                        brew install --cask docker
+                        Write-Verbose "Docker Desktop installed via Homebrew."
+                    }
+                    catch {
+                        Write-Verbose "Docker Desktop Homebrew installation failed: $_"
+                        throw
+                    }
                 }
-                $DockerRetry++
-                Start-Sleep -Seconds 3
             }
-
-            if (-not $DockerReady) {
-                Write-Error "Docker Desktop was installed but the engine did not start within 5 minutes. Please launch Docker Desktop manually and re-run this script."
+            else {
+                Write-Host "Skipping Docker install. Use -SkipOpenWebUI to run Foundry Local without the web interface." -ForegroundColor DarkGray
                 exit 1
             }
-            Write-Host "Docker Desktop is running." -ForegroundColor Green
         }
         else {
-            Write-Host "Skipping Docker install. Use -SkipOpenWebUI to run Foundry Local without the web interface." -ForegroundColor DarkGray
+            # Docker is installed but engine isn't running
+            Write-Host "Docker Desktop is installed but the engine is not running." -ForegroundColor Yellow
+        }
+
+        # Launch Docker Desktop and wait for the engine to be ready
+        Write-Host "Starting Docker Desktop..." -ForegroundColor Cyan
+        if ($Platform -eq "Windows") {
+            $DockerPath = Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+            if (Test-Path $DockerPath) {
+                Start-Process $DockerPath
+            }
+            else {
+                Write-Verbose "Docker Desktop executable not found at expected path, trying shell start..."
+                Start-Process "Docker Desktop"
+            }
+        }
+        elseif ($Platform -eq "macOS") {
+            open -a Docker
+        }
+
+        Write-Host "  Waiting for Docker engine to be ready (up to 5 minutes)..." -ForegroundColor DarkGray
+        $DockerMaxRetries = 100
+        $DockerRetry = 0
+        while ($DockerRetry -lt $DockerMaxRetries) {
+            try {
+                $null = docker info 2>&1
+                if ($LASTEXITCODE -eq 0) {
+                    Write-Verbose "Docker engine is ready."
+                    $DockerReady = $true
+                    break
+                }
+            }
+            catch {
+                # Not ready yet
+            }
+            $DockerRetry++
+            Start-Sleep -Seconds 3
+        }
+
+        if (-not $DockerReady) {
+            Write-Error "Docker Desktop engine did not start within 5 minutes. Please launch Docker Desktop manually and re-run this script."
             exit 1
         }
+        Write-Host "Docker Desktop is running." -ForegroundColor Green
     }
 }
 

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -84,6 +84,9 @@ if ($Cleanup) {
             try {
                 Write-Verbose "Stopping and removing Open WebUI container '$ContainerName'..."
                 docker rm -f $ContainerName | Out-Null
+                if ($LASTEXITCODE -ne 0) {
+                    throw "docker rm exited with code $LASTEXITCODE."
+                }
                 Write-Host "  Removed Docker container '$ContainerName'." -ForegroundColor Green
             }
             catch {
@@ -104,6 +107,9 @@ if ($Cleanup) {
                 try {
                     Write-Verbose "Removing Docker volume '$VolumeName'..."
                     docker volume rm $VolumeName | Out-Null
+                    if ($LASTEXITCODE -ne 0) {
+                        throw "docker volume rm exited with code $LASTEXITCODE."
+                    }
                     Write-Host "  Removed Docker volume '$VolumeName'." -ForegroundColor Green
                 }
                 catch {

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -166,6 +166,43 @@ if ($Cleanup) {
         Write-Host "  No cached model '$Model' found." -ForegroundColor DarkGray
     }
 
+    # Uninstall Foundry Local CLI
+    $FoundryCmd = Get-Command foundry -ErrorAction SilentlyContinue
+    if ($FoundryCmd) {
+        $RemoveFoundry = Read-Host "Uninstall Foundry Local CLI? (Y/N)"
+        if ($RemoveFoundry -eq 'Y' -or $RemoveFoundry -eq 'y') {
+            Write-Verbose "Detecting operating system for uninstall..."
+            if ($IsWindows) {
+                try {
+                    Write-Verbose "Uninstalling Foundry Local via winget..."
+                    winget uninstall Microsoft.FoundryLocal --accept-source-agreements
+                    Write-Host "  Uninstalled Foundry Local CLI." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "winget uninstall failed: $_"
+                    Write-Host "  Could not uninstall Foundry Local. Try: winget uninstall Microsoft.FoundryLocal" -ForegroundColor Yellow
+                }
+            }
+            elseif ($IsMacOS) {
+                try {
+                    Write-Verbose "Uninstalling Foundry Local via Homebrew..."
+                    brew uninstall foundrylocal
+                    Write-Host "  Uninstalled Foundry Local CLI." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "brew uninstall failed: $_"
+                    Write-Host "  Could not uninstall Foundry Local. Try: brew uninstall foundrylocal" -ForegroundColor Yellow
+                }
+            }
+        }
+        else {
+            Write-Host "  Kept Foundry Local CLI installed." -ForegroundColor DarkGray
+        }
+    }
+    else {
+        Write-Host "  Foundry Local CLI not found (already uninstalled)." -ForegroundColor DarkGray
+    }
+
     Write-Host ""
     Write-Host "Cleanup complete." -ForegroundColor Green
     Write-Host "Elapsed time: $($ElapsedTime.Elapsed.ToString('hh\:mm\:ss'))" -ForegroundColor DarkGray

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -164,17 +164,29 @@ if (-not $SkipOpenWebUI) {
         Write-Host "  Waiting for Docker engine to be ready (up to 5 minutes)..." -ForegroundColor DarkGray
         $DockerMaxRetries = 100
         $DockerRetry = 0
+        $DockerCheckTimeout = 5000 # milliseconds per check
         while ($DockerRetry -lt $DockerMaxRetries) {
             try {
-                $null = docker info 2>&1
-                if ($LASTEXITCODE -eq 0) {
+                # Run docker info with a per-check timeout to avoid hanging when engine is stuck
+                $TempOut = [System.IO.Path]::GetTempFileName()
+                $TempErr = [System.IO.Path]::GetTempFileName()
+                $Proc = Start-Process -FilePath "docker" -ArgumentList "info" -NoNewWindow -PassThru -RedirectStandardOutput $TempOut -RedirectStandardError $TempErr
+                $Exited = $Proc.WaitForExit($DockerCheckTimeout)
+                if ($Exited -and $Proc.ExitCode -eq 0) {
                     Write-Verbose "Docker engine is ready."
                     $DockerReady = $true
                     break
                 }
+                if (-not $Exited) {
+                    Write-Verbose "Docker info check timed out (attempt $($DockerRetry + 1)), retrying..."
+                    $Proc.Kill()
+                }
             }
             catch {
                 # Not ready yet
+            }
+            finally {
+                Remove-Item $TempOut, $TempErr -Force -ErrorAction SilentlyContinue
             }
             $DockerRetry++
             Start-Sleep -Seconds 3

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -117,8 +117,45 @@ if (-not $SkipOpenWebUI) {
                     throw
                 }
             }
-            Write-Host "Docker Desktop installed. Please launch it and wait for it to start, then re-run this script." -ForegroundColor Yellow
-            exit 0
+            # Launch Docker Desktop and wait for the engine to be ready
+            Write-Host "Starting Docker Desktop..." -ForegroundColor Cyan
+            if ($Platform -eq "Windows") {
+                $DockerPath = Join-Path $env:ProgramFiles "Docker\Docker\Docker Desktop.exe"
+                if (Test-Path $DockerPath) {
+                    Start-Process $DockerPath
+                } else {
+                    Write-Verbose "Docker Desktop executable not found at expected path, trying shell start..."
+                    Start-Process "Docker Desktop"
+                }
+            }
+            elseif ($Platform -eq "macOS") {
+                open -a Docker
+            }
+
+            Write-Host "  Waiting for Docker engine to be ready..." -ForegroundColor DarkGray
+            $DockerMaxRetries = 60
+            $DockerRetry = 0
+            while ($DockerRetry -lt $DockerMaxRetries) {
+                try {
+                    $DockerVersion = docker version --format '{{.Server.Version}}' 2>$null
+                    if ($DockerVersion) {
+                        Write-Verbose "Docker engine is ready (version $DockerVersion)."
+                        $DockerReady = $true
+                        break
+                    }
+                }
+                catch {
+                    # Not ready yet
+                }
+                $DockerRetry++
+                Start-Sleep -Seconds 3
+            }
+
+            if (-not $DockerReady) {
+                Write-Error "Docker Desktop was installed but the engine did not start within 3 minutes. Please launch Docker Desktop manually and re-run this script."
+                exit 1
+            }
+            Write-Host "Docker Desktop is running." -ForegroundColor Green
         }
         else {
             Write-Host "Skipping Docker install. Use -SkipOpenWebUI to run Foundry Local without the web interface." -ForegroundColor DarkGray

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -58,6 +58,7 @@ Param(
 #region Variables
 
 $ContainerName = "open-webui-foundry"
+$VolumeName = "open-webui-foundry"
 $OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.3.32"
 
 #endregion Variables
@@ -96,14 +97,14 @@ if ($Cleanup) {
         }
 
         # Remove Open WebUI Docker volume
-        $ExistingVolume = docker volume ls --filter "name=open-webui-foundry" --format "{{.Name}}" 2>$null
+        $ExistingVolume = docker volume ls --filter "name=$VolumeName" --format "{{.Name}}" 2>$null
         if ($ExistingVolume) {
             $RemoveVolume = Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)"
             if ($RemoveVolume -eq 'Y' -or $RemoveVolume -eq 'y') {
                 try {
-                    Write-Verbose "Removing Docker volume 'open-webui-foundry'..."
-                    docker volume rm open-webui-foundry | Out-Null
-                    Write-Host "  Removed Docker volume 'open-webui-foundry'." -ForegroundColor Green
+                    Write-Verbose "Removing Docker volume '$VolumeName'..."
+                    docker volume rm $VolumeName | Out-Null
+                    Write-Host "  Removed Docker volume '$VolumeName'." -ForegroundColor Green
                 }
                 catch {
                     Write-Verbose "Failed to remove volume: $_"
@@ -184,6 +185,7 @@ if ($Cleanup) {
                 try {
                     Write-Verbose "Uninstalling Foundry Local via winget..."
                     winget uninstall Microsoft.FoundryLocal --accept-source-agreements
+                    if ($LASTEXITCODE -ne 0) { throw "winget uninstall exited with code $LASTEXITCODE" }
                     Write-Host "  Uninstalled Foundry Local." -ForegroundColor Green
                 }
                 catch {
@@ -195,6 +197,7 @@ if ($Cleanup) {
                 try {
                     Write-Verbose "Uninstalling Foundry Local via Homebrew..."
                     brew uninstall foundrylocal
+                    if ($LASTEXITCODE -ne 0) { throw "brew uninstall exited with code $LASTEXITCODE" }
                     Write-Host "  Uninstalled Foundry Local." -ForegroundColor Green
                 }
                 catch {
@@ -273,6 +276,7 @@ if (-not $SkipOpenWebUI) {
                     try {
                         Write-Verbose "Installing Docker Desktop via winget..."
                         winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
+                        if ($LASTEXITCODE -ne 0) { throw "winget install exited with code $LASTEXITCODE" }
                         Write-Verbose "Docker Desktop installed via winget."
                     }
                     catch {
@@ -284,6 +288,7 @@ if (-not $SkipOpenWebUI) {
                     try {
                         Write-Verbose "Installing Docker Desktop via Homebrew cask..."
                         brew install --cask docker
+                        if ($LASTEXITCODE -ne 0) { throw "brew install exited with code $LASTEXITCODE" }
                         Write-Verbose "Docker Desktop installed via Homebrew."
                     }
                     catch {
@@ -380,6 +385,7 @@ if (-not $FoundryInstalled) {
         try {
             Write-Verbose "Installing via winget..."
             winget install Microsoft.FoundryLocal --accept-source-agreements --accept-package-agreements
+            if ($LASTEXITCODE -ne 0) { throw "winget install exited with code $LASTEXITCODE" }
             Write-Verbose "Foundry Local installed via winget."
         }
         catch {
@@ -391,7 +397,9 @@ if (-not $FoundryInstalled) {
         try {
             Write-Verbose "Installing via Homebrew..."
             brew tap microsoft/foundrylocal
+            if ($LASTEXITCODE -ne 0) { throw "brew tap exited with code $LASTEXITCODE" }
             brew install foundrylocal
+            if ($LASTEXITCODE -ne 0) { throw "brew install exited with code $LASTEXITCODE" }
             Write-Verbose "Foundry Local installed via Homebrew."
         }
         catch {
@@ -451,6 +459,7 @@ else {
     try {
         Write-Verbose "Running 'foundry model download $Model'..."
         foundry model download $Model
+        if ($LASTEXITCODE -ne 0) { throw "foundry model download exited with code $LASTEXITCODE" }
         Write-Verbose "Model '$Model' downloaded successfully."
         Write-Host "Model '$Model' downloaded." -ForegroundColor Green
     }
@@ -465,6 +474,7 @@ Write-Host "Loading model '$Model' into Foundry Local service..." -ForegroundCol
 try {
     Write-Verbose "Running 'foundry model load $Model'..."
     foundry model load $Model
+    if ($LASTEXITCODE -ne 0) { throw "foundry model load exited with code $LASTEXITCODE" }
     Write-Verbose "Model '$Model' loaded successfully."
     Write-Host "Model '$Model' is ready." -ForegroundColor Green
 }
@@ -544,6 +554,7 @@ try {
     Write-Verbose "Pulling Open WebUI Docker image..."
     Write-Host "  Pulling Open WebUI image (this may take a moment)..." -ForegroundColor DarkGray
     docker pull $OpenWebUIImage
+    if ($LASTEXITCODE -ne 0) { throw "docker pull exited with code $LASTEXITCODE" }
     Write-Verbose "Open WebUI image pulled successfully."
 }
 catch {
@@ -561,10 +572,11 @@ try {
         -e "OPENAI_API_BASE_URLS=$FoundryDockerEndpoint" `
         -e "OPENAI_API_KEYS=OPENAI_API_KEY" `
         -e "WEBUI_AUTH=False" `
-        -v "open-webui-foundry:/app/backend/data" `
+        -v "$($VolumeName):/app/backend/data" `
         --name $ContainerName `
         --add-host "host.docker.internal:host-gateway" `
         $OpenWebUIImage | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw "docker run exited with code $LASTEXITCODE" }
     Write-Verbose "Open WebUI container started."
 }
 catch {

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -103,6 +103,7 @@ if (-not $SkipOpenWebUI) {
 
     if (-not $DockerReady) {
         Write-Host "Docker Desktop is required for Open WebUI but was not detected." -ForegroundColor Yellow
+        Write-Host "  (If you recently installed Docker, try restarting your terminal first.)" -ForegroundColor DarkGray
         $Install = Read-Host "Would you like to install Docker Desktop now? (Y/N)"
         if ($Install -eq 'Y' -or $Install -eq 'y') {
             Write-Host "Installing Docker Desktop..." -ForegroundColor Cyan

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -75,42 +75,49 @@ $ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
 if ($Cleanup) {
     Write-Host "Cleaning up Foundry Local demo environment..." -ForegroundColor Cyan
 
-    # Stop and remove Open WebUI container
-    $ExistingContainer = docker ps -a --filter "name=$ContainerName" --format "{{.ID}}" 2>$null
-    if ($ExistingContainer) {
-        try {
-            Write-Verbose "Stopping and removing Open WebUI container '$ContainerName'..."
-            docker rm -f $ContainerName | Out-Null
-            Write-Host "  Removed Docker container '$ContainerName'." -ForegroundColor Green
-        }
-        catch {
-            Write-Verbose "Failed to remove container: $_"
-            Write-Host "  Could not remove container '$ContainerName'." -ForegroundColor Yellow
-        }
-    }
-    else {
-        Write-Verbose "No container named '$ContainerName' found."
-        Write-Host "  No Open WebUI container found (already removed)." -ForegroundColor DarkGray
-    }
-
-    # Remove Open WebUI Docker volume
-    $ExistingVolume = docker volume ls --filter "name=open-webui-foundry" --format "{{.Name}}" 2>$null
-    if ($ExistingVolume) {
-        $RemoveVolume = Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)"
-        if ($RemoveVolume -eq 'Y' -or $RemoveVolume -eq 'y') {
+    # Stop and remove Open WebUI container and volume (only if Docker is available)
+    $DockerCmdCleanup = Get-Command docker -ErrorAction SilentlyContinue
+    if ($DockerCmdCleanup) {
+        $ExistingContainer = docker ps -a --filter "name=$ContainerName" --format "{{.ID}}" 2>$null
+        if ($ExistingContainer) {
             try {
-                Write-Verbose "Removing Docker volume 'open-webui-foundry'..."
-                docker volume rm open-webui-foundry | Out-Null
-                Write-Host "  Removed Docker volume 'open-webui-foundry'." -ForegroundColor Green
+                Write-Verbose "Stopping and removing Open WebUI container '$ContainerName'..."
+                docker rm -f $ContainerName | Out-Null
+                Write-Host "  Removed Docker container '$ContainerName'." -ForegroundColor Green
             }
             catch {
-                Write-Verbose "Failed to remove volume: $_"
-                Write-Host "  Could not remove volume. It may still be in use." -ForegroundColor Yellow
+                Write-Verbose "Failed to remove container: $_"
+                Write-Host "  Could not remove container '$ContainerName'." -ForegroundColor Yellow
             }
         }
         else {
-            Write-Host "  Kept Docker volume (chat history preserved)." -ForegroundColor DarkGray
+            Write-Verbose "No container named '$ContainerName' found."
+            Write-Host "  No Open WebUI container found (already removed)." -ForegroundColor DarkGray
         }
+
+        # Remove Open WebUI Docker volume
+        $ExistingVolume = docker volume ls --filter "name=open-webui-foundry" --format "{{.Name}}" 2>$null
+        if ($ExistingVolume) {
+            $RemoveVolume = Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)"
+            if ($RemoveVolume -eq 'Y' -or $RemoveVolume -eq 'y') {
+                try {
+                    Write-Verbose "Removing Docker volume 'open-webui-foundry'..."
+                    docker volume rm open-webui-foundry | Out-Null
+                    Write-Host "  Removed Docker volume 'open-webui-foundry'." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "Failed to remove volume: $_"
+                    Write-Host "  Could not remove volume. It may still be in use." -ForegroundColor Yellow
+                }
+            }
+            else {
+                Write-Host "  Kept Docker volume (chat history preserved)." -ForegroundColor DarkGray
+            }
+        }
+    }
+    else {
+        Write-Verbose "Docker not found in PATH; skipping container and volume cleanup."
+        Write-Host "  Docker not available — skipped container/volume cleanup." -ForegroundColor DarkGray
     }
 
     # Stop Foundry Local service

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -76,6 +76,11 @@ $OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.8.6"
 
 $ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
 
+# Validate parameter combinations
+if ($Force -and -not $Cleanup) {
+    throw "The -Force parameter is only valid when -Cleanup is specified."
+}
+
 ########################################################################
 #                         Cleanup mode                                 #
 ########################################################################
@@ -689,9 +694,10 @@ try {
     Write-Verbose "Service status output: $ServiceOutput"
 
     # Extract the endpoint URL exactly as reported by the service so the scheme and host are preserved.
-    if ($ServiceOutput -match '(https?://[^/\s]+:(\d+))') {
+    if ($ServiceOutput -match '((https?)://[^/\s]+:(\d+))') {
         $FoundryEndpoint = $Matches[1]
-        $FoundryPort = $Matches[2]
+        $FoundryScheme = $Matches[2]
+        $FoundryPort = $Matches[3]
         Write-Verbose "Foundry Local endpoint detected from service status: $FoundryEndpoint"
         Write-Host "Foundry Local running at $FoundryEndpoint" -ForegroundColor Green
     }
@@ -724,16 +730,17 @@ if ($SkipOpenWebUI) {
 #                     Part 5 - Launch Open WebUI                       #
 ########################################################################
 
-# The Docker container needs to reach the host — use host.docker.internal
-$FoundryDockerEndpoint = "http://host.docker.internal:$FoundryPort/v1"
+# The Docker container needs to reach the host — use host.docker.internal with the detected scheme
+$FoundryDockerEndpoint = "$($FoundryScheme)://host.docker.internal:$FoundryPort/v1"
 
 Write-Host "Setting up Open WebUI..." -ForegroundColor Cyan
 
 # Remove any existing container with the same name
 try {
     Write-Verbose "Checking for existing '$ContainerName' container..."
-    $ExistingContainer = docker ps -a --filter "name=$ContainerName" --format '{{.Names}}' 2>$null
-    if ($ExistingContainer -eq $ContainerName) {
+    # Use an anchored filter so Docker only returns the exact container name
+    $ExistingContainerNames = @(docker ps -a --filter "name=^/$ContainerName$" --format '{{.Names}}' 2>$null)
+    if ($ExistingContainerNames -contains $ContainerName) {
         Write-Verbose "Removing existing container '$ContainerName'..."
         docker rm -f $ContainerName 2>$null | Out-Null
         if ($LASTEXITCODE -ne 0) {
@@ -765,7 +772,7 @@ catch {
 try {
     Write-Verbose "Starting Open WebUI container on port $OpenWebUIPort..."
     docker run -d `
-        -p "$($OpenWebUIPort):8080" `
+        -p "127.0.0.1:$($OpenWebUIPort):8080" `
         -e "OPENAI_API_BASE_URLS=$FoundryDockerEndpoint" `
         -e "OPENAI_API_KEYS=OPENAI_API_KEY" `
         -e "WEBUI_AUTH=False" `

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -79,15 +79,26 @@ Write-Verbose "Running on $Platform."
 if (-not $SkipOpenWebUI) {
     Write-Verbose "Checking for Docker..."
     $DockerReady = $false
-    try {
-        $DockerVersion = docker version --format '{{.Server.Version}}' 2>$null
-        if ($DockerVersion) {
-            $DockerReady = $true
-            Write-Verbose "Docker version $DockerVersion found."
+
+    # First check if docker CLI is available
+    $DockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+    if ($DockerCmd) {
+        Write-Verbose "Docker CLI found at $($DockerCmd.Source)."
+        # Then check if the engine is running
+        try {
+            $DockerInfo = docker info 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                $DockerReady = $true
+                Write-Verbose "Docker engine is running."
+            } else {
+                Write-Verbose "Docker CLI found but engine is not running."
+            }
         }
-    }
-    catch {
-        Write-Verbose "Docker not found or not running."
+        catch {
+            Write-Verbose "Docker engine check failed: $_"
+        }
+    } else {
+        Write-Verbose "Docker CLI not found in PATH."
     }
 
     if (-not $DockerReady) {
@@ -137,9 +148,9 @@ if (-not $SkipOpenWebUI) {
             $DockerRetry = 0
             while ($DockerRetry -lt $DockerMaxRetries) {
                 try {
-                    $DockerVersion = docker version --format '{{.Server.Version}}' 2>$null
-                    if ($DockerVersion) {
-                        Write-Verbose "Docker engine is ready (version $DockerVersion)."
+                    $null = docker info 2>&1
+                    if ($LASTEXITCODE -eq 0) {
+                        Write-Verbose "Docker engine is ready."
                         $DockerReady = $true
                         break
                     }

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -125,8 +125,27 @@ if ($Cleanup) {
     }
 
     # Offer to remove cached model
-    $CacheOutput = foundry cache list 2>&1 | Out-String
-    if ($CacheOutput -match $Model) {
+    try {
+        $TempCacheOut = [System.IO.Path]::GetTempFileName()
+        $TempCacheErr = [System.IO.Path]::GetTempFileName()
+        $CacheProc = Start-Process -FilePath "foundry" -ArgumentList "cache","list" -NoNewWindow -PassThru -RedirectStandardOutput $TempCacheOut -RedirectStandardError $TempCacheErr
+        $CacheExited = $CacheProc.WaitForExit(10000)
+        if (-not $CacheExited) {
+            $CacheProc.Kill()
+            Write-Verbose "foundry cache list timed out."
+            $CacheOutput = ""
+        }
+        else {
+            $CacheOutput = Get-Content $TempCacheOut -Raw -ErrorAction SilentlyContinue
+        }
+        Remove-Item $TempCacheOut, $TempCacheErr -Force -ErrorAction SilentlyContinue
+    }
+    catch {
+        Write-Verbose "Failed to query model cache: $_"
+        $CacheOutput = ""
+    }
+
+    if ($CacheOutput -and $CacheOutput -match $Model) {
         $RemoveModel = Read-Host "Remove cached model '$Model' from disk? (Y/N)"
         if ($RemoveModel -eq 'Y' -or $RemoveModel -eq 'y') {
             try {
@@ -142,6 +161,9 @@ if ($Cleanup) {
         else {
             Write-Host "  Kept model '$Model' in cache." -ForegroundColor DarkGray
         }
+    }
+    else {
+        Write-Host "  No cached model '$Model' found." -ForegroundColor DarkGray
     }
 
     Write-Host ""

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -128,9 +128,10 @@ if ($Cleanup) {
     }
 
     # Stop Foundry Local service
+    $StopTempErr = [System.IO.Path]::GetTempFileName()
     try {
         Write-Verbose "Stopping Foundry Local service..."
-        $StopProc = Start-Process -FilePath "foundry" -ArgumentList "service","stop" -NoNewWindow -Wait -PassThru -RedirectStandardError ([System.IO.Path]::GetTempFileName())
+        $StopProc = Start-Process -FilePath "foundry" -ArgumentList "service","stop" -NoNewWindow -Wait -PassThru -RedirectStandardError $StopTempErr
         if ($StopProc.ExitCode -ne 0) {
             throw "foundry service stop exited with code $($StopProc.ExitCode)."
         }
@@ -140,6 +141,9 @@ if ($Cleanup) {
     catch {
         Write-Verbose "Foundry service stop failed (may not be running): $_"
         Write-Host "  Foundry Local service was not running." -ForegroundColor DarkGray
+    }
+    finally {
+        Remove-Item $StopTempErr -ErrorAction SilentlyContinue
     }
 
     # Offer to remove cached model
@@ -330,6 +334,10 @@ if (-not $SkipOpenWebUI) {
             if ($Install -eq 'Y' -or $Install -eq 'y') {
                 Write-Host "Installing Docker Desktop..." -ForegroundColor Cyan
                 if ($Platform -eq "Windows") {
+                    if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+                        Write-Error "winget is required to install Docker Desktop but was not found. Install winget from https://learn.microsoft.com/en-us/windows/package-manager/winget/ and re-run this script."
+                        exit 1
+                    }
                     try {
                         Write-Verbose "Installing Docker Desktop via winget..."
                         winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
@@ -342,6 +350,10 @@ if (-not $SkipOpenWebUI) {
                     }
                 }
                 elseif ($Platform -eq "macOS") {
+                    if (-not (Get-Command brew -ErrorAction SilentlyContinue)) {
+                        Write-Error "Homebrew (brew) is required to install Docker Desktop but was not found. Install Homebrew from https://brew.sh/ and re-run this script."
+                        exit 1
+                    }
                     try {
                         Write-Verbose "Installing Docker Desktop via Homebrew cask..."
                         brew install --cask docker
@@ -439,6 +451,10 @@ catch {
 if (-not $FoundryInstalled) {
     Write-Host "Installing Foundry Local..." -ForegroundColor Cyan
     if ($Platform -eq "Windows") {
+        if (-not (Get-Command winget -ErrorAction SilentlyContinue)) {
+            Write-Error "winget is required to install Foundry Local but was not found. Install winget from https://learn.microsoft.com/en-us/windows/package-manager/winget/ and re-run this script."
+            exit 1
+        }
         try {
             Write-Verbose "Installing via winget..."
             winget install Microsoft.FoundryLocal --accept-source-agreements --accept-package-agreements
@@ -451,16 +467,28 @@ if (-not $FoundryInstalled) {
         }
     }
     elseif ($Platform -eq "macOS") {
+        if (-not (Get-Command brew -ErrorAction SilentlyContinue)) {
+            Write-Error "Homebrew (brew) is required to install Foundry Local but was not found. Install Homebrew from https://brew.sh/ and re-run this script."
+            exit 1
+        }
         try {
-            Write-Verbose "Installing via Homebrew..."
+            Write-Verbose "Adding the Microsoft Foundry Local Homebrew tap..."
             brew tap microsoft/foundrylocal
             if ($LASTEXITCODE -ne 0) { throw "brew tap exited with code $LASTEXITCODE" }
+            Write-Verbose "Microsoft Foundry Local Homebrew tap added."
+        }
+        catch {
+            Write-Verbose "Homebrew tap failed: $_"
+            throw
+        }
+        try {
+            Write-Verbose "Installing Foundry Local via Homebrew..."
             brew install foundrylocal
             if ($LASTEXITCODE -ne 0) { throw "brew install exited with code $LASTEXITCODE" }
             Write-Verbose "Foundry Local installed via Homebrew."
         }
         catch {
-            Write-Verbose "Homebrew installation failed: $_"
+            Write-Verbose "Homebrew install failed: $_"
             throw
         }
     }
@@ -507,6 +535,8 @@ foreach ($ServiceAction in $ServiceCommands) {
         if (-not $Proc.HasExited) {
             Write-Verbose "foundry service $ServiceAction timed out after $ServiceTimeout seconds, killing process."
             $Proc.Kill()
+            $Proc.WaitForExit()
+            continue
         }
         if ($Proc.ExitCode -eq 0) {
             $ServiceStarted = $true
@@ -533,8 +563,38 @@ if (-not $ServiceStarted) {
 }
 
 # Check if the model is already cached locally
-$CacheOutput = foundry cache list 2>&1 | Out-String
 Write-Verbose "Checking whether model '$Model' is already present in the local cache..."
+$CacheTempOut = [System.IO.Path]::GetTempFileName()
+$CacheTempErr = [System.IO.Path]::GetTempFileName()
+$CacheOutput = ""
+try {
+    Write-Verbose "Running 'foundry cache list'..."
+    $CacheProc = Start-Process -FilePath "foundry" -ArgumentList "cache", "list" `
+        -RedirectStandardOutput $CacheTempOut -RedirectStandardError $CacheTempErr `
+        -PassThru -NoNewWindow
+    $CacheExited = $CacheProc.WaitForExit(60000)
+    if (-not $CacheExited) {
+        Write-Verbose "foundry cache list timed out after 60 seconds, killing process."
+        $CacheProc.Kill()
+        $CacheProc.WaitForExit()
+        throw "foundry cache list timed out after 60 seconds."
+    }
+    if ($CacheProc.ExitCode -ne 0) {
+        $CacheError = Get-Content -Path $CacheTempErr -Raw -ErrorAction SilentlyContinue
+        throw "foundry cache list exited with code $($CacheProc.ExitCode): $CacheError"
+    }
+    $CacheOutput = Get-Content -Path $CacheTempOut -Raw -ErrorAction SilentlyContinue
+    Write-Verbose "'foundry cache list' completed successfully."
+}
+catch {
+    Write-Verbose "Cache check failed: $_"
+    Write-Error "Failed to query the local Foundry cache. Ensure the Foundry Local service is ready, then try again."
+    exit 1
+}
+finally {
+    Remove-Item $CacheTempOut, $CacheTempErr -ErrorAction SilentlyContinue
+}
+
 if ($CacheOutput | Select-String -SimpleMatch -Pattern $Model -Quiet) {
     Write-Verbose "Model '$Model' was found in the local cache."
     Write-Host "Model '$Model' is already downloaded." -ForegroundColor Green
@@ -630,6 +690,9 @@ try {
     if ($ExistingContainer -eq $ContainerName) {
         Write-Verbose "Removing existing container '$ContainerName'..."
         docker rm -f $ContainerName 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            throw "docker rm -f exited with code $LASTEXITCODE"
+        }
         Write-Verbose "Existing container removed."
     }
 }

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -58,7 +58,7 @@ Param(
 #region Variables
 
 $ContainerName = "open-webui-foundry"
-$OpenWebUIImage = "ghcr.io/open-webui/open-webui:main"
+$OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.3.32"
 
 #endregion Variables
 
@@ -145,7 +145,8 @@ if ($Cleanup) {
         $CacheOutput = ""
     }
 
-    if ($CacheOutput -and $CacheOutput -match $Model) {
+    $EscapedModel = [regex]::Escape($Model)
+    if ($CacheOutput -and $CacheOutput -match $EscapedModel) {
         $RemoveModel = Read-Host "Remove cached model '$Model' from disk? (Y/N)"
         if ($RemoveModel -eq 'Y' -or $RemoveModel -eq 'y') {
             try {
@@ -430,10 +431,13 @@ catch {
 
 # Check if the model is already cached locally
 $CacheOutput = foundry cache list 2>&1 | Out-String
-if ($CacheOutput -match $Model) {
+Write-Verbose "Checking whether model '$Model' is already present in the local cache..."
+if ($CacheOutput | Select-String -SimpleMatch -Pattern $Model -Quiet) {
+    Write-Verbose "Model '$Model' was found in the local cache."
     Write-Host "Model '$Model' is already downloaded." -ForegroundColor Green
 }
 else {
+    Write-Verbose "Model '$Model' was not found in the local cache."
     Write-Host "Downloading model '$Model'..." -ForegroundColor Cyan
     Write-Host "  (This may take several minutes on first run depending on your connection)" -ForegroundColor DarkGray
     Write-Host "  Tip: Run 'foundry cache list' in another terminal to check download status." -ForegroundColor DarkGray

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -327,8 +327,26 @@ if (-not $SkipOpenWebUI) {
     Write-Verbose "Checking for Docker..."
     $DockerReady = $false
 
-    # First check if docker CLI is available
+    # First check if docker CLI is available (PATH, then well-known install locations)
     $DockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $DockerCmd) {
+        Write-Verbose "Docker CLI not found in PATH, checking well-known install locations..."
+        $WellKnownPaths = if ($IsWindows) {
+            @("$env:ProgramFiles\Docker\Docker\resources\bin\docker.exe")
+        } else {
+            @("/usr/local/bin/docker", "/opt/homebrew/bin/docker",
+              "/Applications/Docker.app/Contents/Resources/bin/docker")
+        }
+        foreach ($DockerPath in $WellKnownPaths) {
+            if (Test-Path $DockerPath) {
+                Write-Verbose "Found Docker at well-known path: $DockerPath"
+                $ParentDir = Split-Path $DockerPath -Parent
+                $env:PATH = "$ParentDir$([System.IO.Path]::PathSeparator)$env:PATH"
+                $DockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+                break
+            }
+        }
+    }
     if ($DockerCmd) {
         Write-Verbose "Docker CLI found at $($DockerCmd.Source)."
         # Then check if the engine is running
@@ -367,7 +385,8 @@ if (-not $SkipOpenWebUI) {
                     try {
                         Write-Verbose "Installing Docker Desktop via winget..."
                         winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
-                        if ($LASTEXITCODE -ne 0) { throw "winget install exited with code $LASTEXITCODE" }
+                        # winget returns -1978335189 when the package is already installed with no upgrade available
+                        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) { throw "winget install exited with code $LASTEXITCODE" }
                         Write-Verbose "Docker Desktop installed via winget."
                     }
                     catch {
@@ -484,7 +503,7 @@ if (-not $FoundryInstalled) {
         try {
             Write-Verbose "Installing via winget..."
             winget install Microsoft.FoundryLocal --accept-source-agreements --accept-package-agreements
-            if ($LASTEXITCODE -ne 0) { throw "winget install exited with code $LASTEXITCODE" }
+            if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) { throw "winget install exited with code $LASTEXITCODE" }
             Write-Verbose "Foundry Local installed via winget."
         }
         catch {

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -133,7 +133,7 @@ if (-not $SkipOpenWebUI) {
             }
 
             Write-Host "  Waiting for Docker engine to be ready..." -ForegroundColor DarkGray
-            $DockerMaxRetries = 60
+            $DockerMaxRetries = 100
             $DockerRetry = 0
             while ($DockerRetry -lt $DockerMaxRetries) {
                 try {
@@ -152,7 +152,7 @@ if (-not $SkipOpenWebUI) {
             }
 
             if (-not $DockerReady) {
-                Write-Error "Docker Desktop was installed but the engine did not start within 3 minutes. Please launch Docker Desktop manually and re-run this script."
+                Write-Error "Docker Desktop was installed but the engine did not start within 5 minutes. Please launch Docker Desktop manually and re-run this script."
                 exit 1
             }
             Write-Host "Docker Desktop is running." -ForegroundColor Green

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -1,0 +1,346 @@
+#Requires -Version 7.0
+[CmdletBinding()]
+
+<#
+.SYNOPSIS
+    Deploys Foundry Local with an Open WebUI chat interface.
+
+.DESCRIPTION
+    This script sets up Microsoft Foundry Local and Open WebUI for a local AI
+    chat experience. It installs the Foundry Local CLI (if needed), downloads
+    and loads an AI model, and launches Open WebUI via Docker for a browser-based
+    chat interface. Everything runs on your device with no cloud dependency.
+
+    Supports both Windows and macOS. The default model is qwen2.5-0.5b (the
+    smallest available). Specify a different model with the -Model parameter.
+    Run 'foundry model list' to see all available models after Foundry Local
+    is installed.
+
+.PARAMETER Model
+    The Foundry Local model alias to download and load.
+    Defaults to 'qwen2.5-0.5b' (smallest available model).
+    Examples: 'phi-4-mini', 'phi-3.5-mini', 'deepseek-r1-7b'
+
+.PARAMETER OpenWebUIPort
+    The local port on which Open WebUI will be accessible.
+    Defaults to 3000.
+
+.PARAMETER SkipOpenWebUI
+    If specified, only sets up Foundry Local without launching Open WebUI.
+    Useful if you only want the Foundry Local service running.
+
+.LINK
+    https://learn.microsoft.com/en-us/azure/foundry-local/what-is-foundry-local
+    https://github.com/microsoft/Foundry-Local
+    https://docs.openwebui.com/
+#>
+
+Param(
+    [Parameter(HelpMessage = "Model alias to load (e.g., 'qwen2.5-0.5b', 'phi-4-mini')")]
+    [string]$Model = "qwen2.5-0.5b",
+
+    [Parameter(HelpMessage = "Local port for Open WebUI (default: 3000)")]
+    [ValidateRange(1024, 65535)]
+    [int]$OpenWebUIPort = 3000,
+
+    [Parameter(HelpMessage = "Skip Open WebUI setup and only start Foundry Local")]
+    [switch]$SkipOpenWebUI
+)
+
+#region Variables
+
+$ContainerName = "open-webui-foundry"
+$OpenWebUIImage = "ghcr.io/open-webui/open-webui:main"
+
+#endregion Variables
+
+########################################################################
+#                      DO NOT EDIT BELOW THIS LINE                     #
+########################################################################
+
+$ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
+
+########################################################################
+#                         Part 1 - Prerequisites                       #
+########################################################################
+
+Write-Verbose "Detecting operating system..."
+if ($IsWindows) {
+    $Platform = "Windows"
+} elseif ($IsMacOS) {
+    $Platform = "macOS"
+} else {
+    Write-Error "This script supports Windows and macOS only."
+    exit 1
+}
+Write-Verbose "Running on $Platform."
+
+# Check Docker (required for Open WebUI)
+if (-not $SkipOpenWebUI) {
+    Write-Verbose "Checking for Docker..."
+    try {
+        $DockerVersion = docker version --format '{{.Server.Version}}' 2>$null
+        if (-not $DockerVersion) {
+            throw "Docker is not running."
+        }
+        Write-Verbose "Docker version $DockerVersion found."
+    }
+    catch {
+        Write-Verbose "Docker check failed."
+        Write-Error "Docker Desktop is required for Open WebUI. Install it from https://www.docker.com/products/docker-desktop/ and ensure it is running. Alternatively, use -SkipOpenWebUI to run Foundry Local without the web interface."
+        exit 1
+    }
+}
+
+########################################################################
+#                  Part 2 - Install Foundry Local CLI                   #
+########################################################################
+
+Write-Verbose "Checking if Foundry Local CLI is installed..."
+$FoundryInstalled = $false
+try {
+    $FoundryVersion = foundry --version 2>$null
+    if ($FoundryVersion) {
+        $FoundryInstalled = $true
+        Write-Verbose "Foundry Local CLI is already installed: $FoundryVersion"
+    }
+}
+catch {
+    Write-Verbose "Foundry Local CLI not found."
+}
+
+if (-not $FoundryInstalled) {
+    Write-Host "Installing Foundry Local CLI..." -ForegroundColor Cyan
+    if ($Platform -eq "Windows") {
+        try {
+            Write-Verbose "Installing via winget..."
+            winget install Microsoft.FoundryLocal --accept-source-agreements --accept-package-agreements
+            Write-Verbose "Foundry Local CLI installed via winget."
+        }
+        catch {
+            Write-Verbose "winget installation failed: $_"
+            throw
+        }
+    }
+    elseif ($Platform -eq "macOS") {
+        try {
+            Write-Verbose "Installing via Homebrew..."
+            brew tap microsoft/foundrylocal
+            brew install foundrylocal
+            Write-Verbose "Foundry Local CLI installed via Homebrew."
+        }
+        catch {
+            Write-Verbose "Homebrew installation failed: $_"
+            throw
+        }
+    }
+
+    # Verify installation
+    try {
+        $FoundryVersion = foundry --version
+        Write-Host "Foundry Local CLI installed: $FoundryVersion" -ForegroundColor Green
+    }
+    catch {
+        Write-Verbose "Post-install verification failed: $_"
+        Write-Error "Foundry Local CLI installation could not be verified. You may need to restart your terminal and try again."
+        exit 1
+    }
+}
+
+########################################################################
+#          Part 3 - Start Foundry Local service and load model         #
+########################################################################
+
+Write-Host "Starting Foundry Local service..." -ForegroundColor Cyan
+try {
+    Write-Verbose "Restarting Foundry Local service to ensure a clean state..."
+    foundry service start 2>$null
+    Write-Verbose "Foundry Local service started."
+}
+catch {
+    Write-Verbose "Service start attempt failed, trying restart: $_"
+    try {
+        foundry service restart
+        Write-Verbose "Foundry Local service restarted successfully."
+    }
+    catch {
+        Write-Verbose "Service restart also failed: $_"
+        throw
+    }
+}
+
+Write-Host "Downloading and loading model '$Model'..." -ForegroundColor Cyan
+Write-Host "  (This may take a while on first run as the model is downloaded)" -ForegroundColor DarkGray
+try {
+    Write-Verbose "Running 'foundry model load $Model'..."
+    foundry model download $Model
+    foundry model load $Model
+    Write-Verbose "Model '$Model' loaded successfully."
+    Write-Host "Model '$Model' is ready." -ForegroundColor Green
+}
+catch {
+    Write-Verbose "Model load failed: $_"
+    Write-Error "Failed to load model '$Model'. Run 'foundry model list' to see available models."
+    exit 1
+}
+
+########################################################################
+#              Part 4 - Get Foundry Local endpoint                     #
+########################################################################
+
+Write-Host "Getting Foundry Local endpoint..." -ForegroundColor Cyan
+try {
+    Write-Verbose "Querying Foundry Local service status..."
+    $ServiceOutput = foundry service status 2>&1 | Out-String
+    Write-Verbose "Service status output: $ServiceOutput"
+
+    # Extract the endpoint URL (e.g., http://127.0.0.1:XXXXX or http://localhost:XXXXX)
+    if ($ServiceOutput -match 'https?://[^/\s]+:(\d+)') {
+        $FoundryPort = $Matches[1]
+        $FoundryEndpoint = "http://127.0.0.1:$FoundryPort"
+        Write-Verbose "Foundry Local endpoint: $FoundryEndpoint"
+        Write-Host "Foundry Local running at $FoundryEndpoint" -ForegroundColor Green
+    }
+    else {
+        throw "Could not parse the Foundry Local endpoint from service status output."
+    }
+}
+catch {
+    Write-Verbose "Endpoint detection failed: $_"
+    Write-Error "Failed to determine Foundry Local endpoint. Run 'foundry service status' manually to check."
+    exit 1
+}
+
+if ($SkipOpenWebUI) {
+    Write-Host ""
+    Write-Host "========================================" -ForegroundColor Green
+    Write-Host " Foundry Local is ready!" -ForegroundColor Green
+    Write-Host "========================================" -ForegroundColor Green
+    Write-Host " Endpoint : $FoundryEndpoint" -ForegroundColor White
+    Write-Host " Model    : $Model" -ForegroundColor White
+    Write-Host ""
+    Write-Host " Test it with:" -ForegroundColor DarkGray
+    Write-Host "   foundry model run $Model" -ForegroundColor DarkGray
+    Write-Host ""
+    Write-Host "Elapsed time: $($ElapsedTime.Elapsed.ToString('hh\:mm\:ss'))" -ForegroundColor DarkGray
+    exit 0
+}
+
+########################################################################
+#                     Part 5 - Launch Open WebUI                       #
+########################################################################
+
+# The Docker container needs to reach the host — use host.docker.internal
+$FoundryDockerEndpoint = "http://host.docker.internal:$FoundryPort/v1"
+
+Write-Host "Setting up Open WebUI..." -ForegroundColor Cyan
+
+# Remove any existing container with the same name
+try {
+    Write-Verbose "Checking for existing '$ContainerName' container..."
+    $ExistingContainer = docker ps -a --filter "name=$ContainerName" --format '{{.Names}}' 2>$null
+    if ($ExistingContainer -eq $ContainerName) {
+        Write-Verbose "Removing existing container '$ContainerName'..."
+        docker rm -f $ContainerName 2>$null | Out-Null
+        Write-Verbose "Existing container removed."
+    }
+}
+catch {
+    Write-Verbose "Container cleanup check failed (non-fatal): $_"
+}
+
+# Pull the Open WebUI image
+try {
+    Write-Verbose "Pulling Open WebUI Docker image..."
+    Write-Host "  Pulling Open WebUI image (this may take a moment)..." -ForegroundColor DarkGray
+    docker pull $OpenWebUIImage
+    Write-Verbose "Open WebUI image pulled successfully."
+}
+catch {
+    Write-Verbose "Docker pull failed: $_"
+    throw
+}
+
+# Start the container
+# DEMO SHORTCUT: WEBUI_AUTH=False disables authentication for demo simplicity.
+# This is NOT suitable for production use — always enable auth in real deployments.
+try {
+    Write-Verbose "Starting Open WebUI container on port $OpenWebUIPort..."
+    docker run -d `
+        -p "$($OpenWebUIPort):8080" `
+        -e "OPENAI_API_BASE_URLS=$FoundryDockerEndpoint" `
+        -e "OPENAI_API_KEYS=OPENAI_API_KEY" `
+        -e "WEBUI_AUTH=False" `
+        -v "open-webui-foundry:/app/backend/data" `
+        --name $ContainerName `
+        --add-host "host.docker.internal:host-gateway" `
+        $OpenWebUIImage | Out-Null
+    Write-Verbose "Open WebUI container started."
+}
+catch {
+    Write-Verbose "Failed to start Open WebUI container: $_"
+    throw
+}
+
+# Wait for Open WebUI to become responsive
+Write-Host "  Waiting for Open WebUI to start..." -ForegroundColor DarkGray
+$MaxRetries = 30
+$RetryCount = 0
+$WebUIReady = $false
+while ($RetryCount -lt $MaxRetries) {
+    try {
+        $Response = Invoke-WebRequest -Uri "http://localhost:$OpenWebUIPort" -TimeoutSec 2 -ErrorAction SilentlyContinue
+        if ($Response.StatusCode -eq 200) {
+            $WebUIReady = $true
+            break
+        }
+    }
+    catch {
+        # Not ready yet
+    }
+    $RetryCount++
+    Start-Sleep -Seconds 2
+}
+
+if (-not $WebUIReady) {
+    Write-Host "  Open WebUI may still be starting up. Check http://localhost:$OpenWebUIPort in a moment." -ForegroundColor Yellow
+} else {
+    Write-Verbose "Open WebUI is responsive."
+}
+
+########################################################################
+#                       Part 6 - Open browser                         #
+########################################################################
+
+$WebUIUrl = "http://localhost:$OpenWebUIPort"
+Write-Host ""
+Write-Host "========================================" -ForegroundColor Green
+Write-Host " Foundry Local + Open WebUI is ready!" -ForegroundColor Green
+Write-Host "========================================" -ForegroundColor Green
+Write-Host " Open WebUI : $WebUIUrl" -ForegroundColor White
+Write-Host " Foundry API: $FoundryEndpoint" -ForegroundColor White
+Write-Host " Model      : $Model" -ForegroundColor White
+Write-Host ""
+Write-Host " If the model does not appear in Open WebUI," -ForegroundColor DarkGray
+Write-Host " add a Direct Connection in Settings > Connections:" -ForegroundColor DarkGray
+Write-Host "   URL : http://host.docker.internal:$FoundryPort/v1" -ForegroundColor DarkGray
+Write-Host "   Auth: None" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host " To stop: docker rm -f $ContainerName && foundry service stop" -ForegroundColor DarkGray
+Write-Host ""
+Write-Host "Elapsed time: $($ElapsedTime.Elapsed.ToString('hh\:mm\:ss'))" -ForegroundColor DarkGray
+
+# Open the browser
+try {
+    Write-Verbose "Opening browser to $WebUIUrl..."
+    if ($Platform -eq "Windows") {
+        Start-Process $WebUIUrl
+    }
+    elseif ($Platform -eq "macOS") {
+        open $WebUIUrl
+    }
+}
+catch {
+    Write-Verbose "Could not auto-open browser: $_"
+    Write-Host "Open your browser to $WebUIUrl" -ForegroundColor Yellow
+}

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -829,7 +829,7 @@ Write-Host " Model      : $Model" -ForegroundColor White
 Write-Host ""
 Write-Host " If the model does not appear in Open WebUI," -ForegroundColor DarkGray
 Write-Host " add a Direct Connection in Settings > Connections:" -ForegroundColor DarkGray
-Write-Host "   URL : http://host.docker.internal:$FoundryPort/v1" -ForegroundColor DarkGray
+Write-Host "   URL : $FoundryDockerEndpoint/v1" -ForegroundColor DarkGray
 Write-Host "   Auth: None" -ForegroundColor DarkGray
 Write-Host ""
 Write-Host " To stop: docker rm -f $ContainerName && foundry service stop" -ForegroundColor DarkGray

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -124,7 +124,11 @@ if ($Cleanup) {
     # Stop Foundry Local service
     try {
         Write-Verbose "Stopping Foundry Local service..."
-        foundry service stop 2>$null
+        $StopProc = Start-Process -FilePath "foundry" -ArgumentList "service","stop" -NoNewWindow -Wait -PassThru -RedirectStandardError ([System.IO.Path]::GetTempFileName())
+        if ($StopProc.ExitCode -ne 0) {
+            throw "foundry service stop exited with code $($StopProc.ExitCode)."
+        }
+        Write-Verbose "Successfully stopped Foundry Local service."
         Write-Host "  Stopped Foundry Local service." -ForegroundColor Green
     }
     catch {
@@ -159,8 +163,16 @@ if ($Cleanup) {
         if ($RemoveModel -eq 'Y' -or $RemoveModel -eq 'y') {
             try {
                 Write-Verbose "Removing model '$Model' from cache..."
-                foundry cache rm $Model
-                Write-Host "  Removed model '$Model' from cache." -ForegroundColor Green
+                $RemoveCacheProc = Start-Process -FilePath "foundry" -ArgumentList "cache", "rm", $Model -NoNewWindow -PassThru
+                $null = $RemoveCacheProc.WaitForExit()
+                if ($RemoveCacheProc.ExitCode -eq 0) {
+                    Write-Verbose "Successfully removed model '$Model' from cache."
+                    Write-Host "  Removed model '$Model' from cache." -ForegroundColor Green
+                }
+                else {
+                    Write-Verbose "Failed to remove model '$Model' from cache. foundry exited with code $($RemoveCacheProc.ExitCode)."
+                    Write-Host "  Could not remove model from cache." -ForegroundColor Yellow
+                }
             }
             catch {
                 Write-Verbose "Failed to remove model from cache: $_"
@@ -562,11 +574,11 @@ try {
     $ServiceOutput = foundry service status 2>&1 | Out-String
     Write-Verbose "Service status output: $ServiceOutput"
 
-    # Extract the endpoint URL (e.g., http://127.0.0.1:XXXXX or http://localhost:XXXXX)
-    if ($ServiceOutput -match 'https?://[^/\s]+:(\d+)') {
-        $FoundryPort = $Matches[1]
-        $FoundryEndpoint = "http://127.0.0.1:$FoundryPort"
-        Write-Verbose "Foundry Local endpoint: $FoundryEndpoint"
+    # Extract the endpoint URL exactly as reported by the service so the scheme and host are preserved.
+    if ($ServiceOutput -match '(https?://[^/\s]+:(\d+))') {
+        $FoundryEndpoint = $Matches[1]
+        $FoundryPort = $Matches[2]
+        Write-Verbose "Foundry Local endpoint detected from service status: $FoundryEndpoint"
         Write-Host "Foundry Local running at $FoundryEndpoint" -ForegroundColor Green
     }
     else {

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -464,23 +464,52 @@ if (-not $FoundryInstalled) {
 ########################################################################
 
 Write-Host "Starting Foundry Local service..." -ForegroundColor Cyan
-try {
-    Write-Verbose "Restarting Foundry Local service to ensure a clean state..."
-    $null = foundry service start 2>&1 | Out-String
-    Write-Verbose "Foundry Local service started."
-    Write-Host "Foundry Local service is running." -ForegroundColor Green
-}
-catch {
-    Write-Verbose "Service start attempt failed, trying restart: $_"
+Write-Verbose "Starting Foundry Local service (timeout: 3 minutes)..."
+
+$ServiceStarted = $false
+$ServiceCommands = @("start", "restart")
+foreach ($ServiceAction in $ServiceCommands) {
+    Write-Verbose "Attempting 'foundry service $ServiceAction'..."
+    $TempOut = [System.IO.Path]::GetTempFileName()
     try {
-        $null = foundry service restart 2>&1 | Out-String
-        Write-Verbose "Foundry Local service restarted successfully."
-        Write-Host "Foundry Local service is running." -ForegroundColor Green
+        $Proc = Start-Process -FilePath "foundry" -ArgumentList "service", $ServiceAction `
+            -RedirectStandardOutput $TempOut -RedirectStandardError ([System.IO.Path]::GetTempFileName()) `
+            -PassThru -NoNewWindow
+        # Wait up to 3 minutes for the service to start
+        $ServiceTimeout = 180
+        $Waited = 0
+        while (-not $Proc.HasExited -and $Waited -lt $ServiceTimeout) {
+            Start-Sleep -Seconds 2
+            $Waited += 2
+            if ($Waited % 10 -eq 0) {
+                Write-Host "  Still waiting for Foundry Local service to $ServiceAction... ($Waited`s)" -ForegroundColor DarkGray
+            }
+        }
+        if (-not $Proc.HasExited) {
+            Write-Verbose "foundry service $ServiceAction timed out after $ServiceTimeout seconds, killing process."
+            $Proc.Kill()
+        }
+        if ($Proc.ExitCode -eq 0) {
+            $ServiceStarted = $true
+            Write-Verbose "Foundry Local service $($ServiceAction) succeeded."
+            Write-Host "Foundry Local service is running." -ForegroundColor Green
+            break
+        }
+        else {
+            Write-Verbose "foundry service $ServiceAction exited with code $($Proc.ExitCode)."
+        }
     }
     catch {
-        Write-Verbose "Service restart also failed: $_"
-        throw
+        Write-Verbose "foundry service $ServiceAction failed: $_"
     }
+    finally {
+        Remove-Item $TempOut -ErrorAction SilentlyContinue
+    }
+}
+
+if (-not $ServiceStarted) {
+    Write-Error "Failed to start Foundry Local service. Try running 'foundry service start' manually."
+    exit 1
 }
 
 # Check if the model is already cached locally

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -214,6 +214,45 @@ if ($Cleanup) {
         Write-Host "  Foundry Local not found (already uninstalled)." -ForegroundColor DarkGray
     }
 
+    # Uninstall Docker Desktop
+    $DockerCmd = Get-Command docker -ErrorAction SilentlyContinue
+    if ($DockerCmd) {
+        $RemoveDocker = Read-Host "Uninstall Docker Desktop? (Y/N)"
+        if ($RemoveDocker -eq 'Y' -or $RemoveDocker -eq 'y') {
+            Write-Verbose "Detecting operating system for Docker uninstall..."
+            if ($IsWindows) {
+                try {
+                    Write-Verbose "Uninstalling Docker Desktop via winget..."
+                    winget uninstall Docker.DockerDesktop --accept-source-agreements
+                    if ($LASTEXITCODE -ne 0) { throw "winget uninstall exited with code $LASTEXITCODE" }
+                    Write-Host "  Uninstalled Docker Desktop." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "winget uninstall failed: $_"
+                    Write-Host "  Could not uninstall Docker Desktop. Try: winget uninstall Docker.DockerDesktop" -ForegroundColor Yellow
+                }
+            }
+            elseif ($IsMacOS) {
+                try {
+                    Write-Verbose "Uninstalling Docker Desktop via Homebrew..."
+                    brew uninstall --cask docker
+                    if ($LASTEXITCODE -ne 0) { throw "brew uninstall exited with code $LASTEXITCODE" }
+                    Write-Host "  Uninstalled Docker Desktop." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "brew uninstall failed: $_"
+                    Write-Host "  Could not uninstall Docker Desktop. Try: brew uninstall --cask docker" -ForegroundColor Yellow
+                }
+            }
+        }
+        else {
+            Write-Host "  Kept Docker Desktop installed." -ForegroundColor DarkGray
+        }
+    }
+    else {
+        Write-Host "  Docker Desktop not found (already uninstalled)." -ForegroundColor DarkGray
+    }
+
     Write-Host ""
     Write-Host "Cleanup complete." -ForegroundColor Green
     Write-Host "Elapsed time: $($ElapsedTime.Elapsed.ToString('hh\:mm\:ss'))" -ForegroundColor DarkGray

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -59,7 +59,7 @@ Param(
 
 $ContainerName = "open-webui-foundry"
 $VolumeName = "open-webui-foundry"
-$OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.3.32"
+$OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.8.6"
 
 #endregion Variables
 

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -489,9 +489,10 @@ $ServiceCommands = @("start", "restart")
 foreach ($ServiceAction in $ServiceCommands) {
     Write-Verbose "Attempting 'foundry service $ServiceAction'..."
     $TempOut = [System.IO.Path]::GetTempFileName()
+    $TempErr = [System.IO.Path]::GetTempFileName()
     try {
         $Proc = Start-Process -FilePath "foundry" -ArgumentList "service", $ServiceAction `
-            -RedirectStandardOutput $TempOut -RedirectStandardError ([System.IO.Path]::GetTempFileName()) `
+            -RedirectStandardOutput $TempOut -RedirectStandardError $TempErr `
             -PassThru -NoNewWindow
         # Wait up to 3 minutes for the service to start
         $ServiceTimeout = 180
@@ -522,6 +523,7 @@ foreach ($ServiceAction in $ServiceCommands) {
     }
     finally {
         Remove-Item $TempOut -ErrorAction SilentlyContinue
+        Remove-Item $TempErr -ErrorAction SilentlyContinue
     }
 }
 

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -7,7 +7,7 @@
 
 .DESCRIPTION
     This script sets up Microsoft Foundry Local and Open WebUI for a local AI
-    chat experience. It installs the Foundry Local CLI (if needed), downloads
+    chat experience. It installs Foundry Local (if needed), downloads
     and loads an AI model, and launches Open WebUI via Docker for a browser-based
     chat interface. Everything runs on your device with no cloud dependency.
 
@@ -31,8 +31,8 @@
 
 .PARAMETER Cleanup
     If specified, tears down the demo environment: stops and removes the
-    Open WebUI Docker container and volume, and stops the Foundry Local service.
-    Optionally removes the cached model from disk.
+    Open WebUI Docker container and volume, stops the Foundry Local service,
+    and optionally uninstalls Foundry Local.
 
 .LINK
     https://learn.microsoft.com/en-us/azure/foundry-local/what-is-foundry-local
@@ -166,17 +166,17 @@ if ($Cleanup) {
         Write-Host "  No cached model '$Model' found." -ForegroundColor DarkGray
     }
 
-    # Uninstall Foundry Local CLI
+    # Uninstall Foundry Local
     $FoundryCmd = Get-Command foundry -ErrorAction SilentlyContinue
     if ($FoundryCmd) {
-        $RemoveFoundry = Read-Host "Uninstall Foundry Local CLI? (Y/N)"
+        $RemoveFoundry = Read-Host "Uninstall Foundry Local? (Y/N)"
         if ($RemoveFoundry -eq 'Y' -or $RemoveFoundry -eq 'y') {
             Write-Verbose "Detecting operating system for uninstall..."
             if ($IsWindows) {
                 try {
                     Write-Verbose "Uninstalling Foundry Local via winget..."
                     winget uninstall Microsoft.FoundryLocal --accept-source-agreements
-                    Write-Host "  Uninstalled Foundry Local CLI." -ForegroundColor Green
+                    Write-Host "  Uninstalled Foundry Local." -ForegroundColor Green
                 }
                 catch {
                     Write-Verbose "winget uninstall failed: $_"
@@ -187,7 +187,7 @@ if ($Cleanup) {
                 try {
                     Write-Verbose "Uninstalling Foundry Local via Homebrew..."
                     brew uninstall foundrylocal
-                    Write-Host "  Uninstalled Foundry Local CLI." -ForegroundColor Green
+                    Write-Host "  Uninstalled Foundry Local." -ForegroundColor Green
                 }
                 catch {
                     Write-Verbose "brew uninstall failed: $_"
@@ -196,11 +196,11 @@ if ($Cleanup) {
             }
         }
         else {
-            Write-Host "  Kept Foundry Local CLI installed." -ForegroundColor DarkGray
+            Write-Host "  Kept Foundry Local installed." -ForegroundColor DarkGray
         }
     }
     else {
-        Write-Host "  Foundry Local CLI not found (already uninstalled)." -ForegroundColor DarkGray
+        Write-Host "  Foundry Local not found (already uninstalled)." -ForegroundColor DarkGray
     }
 
     Write-Host ""
@@ -350,29 +350,29 @@ if (-not $SkipOpenWebUI) {
 }
 
 ########################################################################
-#                  Part 2 - Install Foundry Local CLI                   #
+#                  Part 2 - Install Foundry Local                   #
 ########################################################################
 
-Write-Verbose "Checking if Foundry Local CLI is installed..."
+Write-Verbose "Checking if Foundry Local is installed..."
 $FoundryInstalled = $false
 try {
     $FoundryVersion = foundry --version 2>$null
     if ($FoundryVersion) {
         $FoundryInstalled = $true
-        Write-Verbose "Foundry Local CLI is already installed: $FoundryVersion"
+        Write-Verbose "Foundry Local is already installed: $FoundryVersion"
     }
 }
 catch {
-    Write-Verbose "Foundry Local CLI not found."
+    Write-Verbose "Foundry Local not found."
 }
 
 if (-not $FoundryInstalled) {
-    Write-Host "Installing Foundry Local CLI..." -ForegroundColor Cyan
+    Write-Host "Installing Foundry Local..." -ForegroundColor Cyan
     if ($Platform -eq "Windows") {
         try {
             Write-Verbose "Installing via winget..."
             winget install Microsoft.FoundryLocal --accept-source-agreements --accept-package-agreements
-            Write-Verbose "Foundry Local CLI installed via winget."
+            Write-Verbose "Foundry Local installed via winget."
         }
         catch {
             Write-Verbose "winget installation failed: $_"
@@ -384,7 +384,7 @@ if (-not $FoundryInstalled) {
             Write-Verbose "Installing via Homebrew..."
             brew tap microsoft/foundrylocal
             brew install foundrylocal
-            Write-Verbose "Foundry Local CLI installed via Homebrew."
+            Write-Verbose "Foundry Local installed via Homebrew."
         }
         catch {
             Write-Verbose "Homebrew installation failed: $_"
@@ -395,11 +395,11 @@ if (-not $FoundryInstalled) {
     # Verify installation
     try {
         $FoundryVersion = foundry --version
-        Write-Host "Foundry Local CLI installed: $FoundryVersion" -ForegroundColor Green
+        Write-Host "Foundry Local installed: $FoundryVersion" -ForegroundColor Green
     }
     catch {
         Write-Verbose "Post-install verification failed: $_"
-        Write-Error "Foundry Local CLI installation could not be verified. You may need to restart your terminal and try again."
+        Write-Error "Foundry Local installation could not be verified. You may need to restart your terminal and try again."
         exit 1
     }
 }

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -34,6 +34,10 @@
     Open WebUI Docker container and volume, stops the Foundry Local service,
     and optionally uninstalls Foundry Local.
 
+.PARAMETER Force
+    When used with -Cleanup, skips all confirmation prompts and removes
+    everything without asking.
+
 .LINK
     https://learn.microsoft.com/en-us/azure/foundry-local/what-is-foundry-local
     https://github.com/microsoft/Foundry-Local
@@ -52,7 +56,10 @@ Param(
     [switch]$SkipOpenWebUI,
 
     [Parameter(HelpMessage = "Tear down the demo environment (remove containers, stop services)")]
-    [switch]$Cleanup
+    [switch]$Cleanup,
+
+    [Parameter(HelpMessage = "Skip all confirmation prompts during cleanup (remove everything)")]
+    [switch]$Force
 )
 
 #region Variables
@@ -102,8 +109,7 @@ if ($Cleanup) {
         # Remove Open WebUI Docker volume
         $ExistingVolume = docker volume ls --filter "name=$VolumeName" --format "{{.Name}}" 2>$null
         if ($ExistingVolume) {
-            $RemoveVolume = Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)"
-            if ($RemoveVolume -eq 'Y' -or $RemoveVolume -eq 'y') {
+            if ($Force -or (Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)") -match '^[Yy]$') {
                 try {
                     Write-Verbose "Removing Docker volume '$VolumeName'..."
                     docker volume rm $VolumeName | Out-Null
@@ -119,6 +125,26 @@ if ($Cleanup) {
             }
             else {
                 Write-Host "  Kept Docker volume (chat history preserved)." -ForegroundColor DarkGray
+            }
+        }
+
+        # Remove Open WebUI Docker image
+        $ExistingImage = docker images $OpenWebUIImage --format "{{.ID}}" 2>$null
+        if ($ExistingImage) {
+            if ($Force -or (Read-Host "Remove Open WebUI Docker image ($OpenWebUIImage)? (Y/N)") -match '^[Yy]$') {
+                try {
+                    Write-Verbose "Removing Docker image '$OpenWebUIImage'..."
+                    docker rmi $OpenWebUIImage | Out-Null
+                    if ($LASTEXITCODE -ne 0) { throw "docker rmi exited with code $LASTEXITCODE" }
+                    Write-Host "  Removed Docker image '$OpenWebUIImage'." -ForegroundColor Green
+                }
+                catch {
+                    Write-Verbose "Failed to remove Docker image: $_"
+                    Write-Host "  Could not remove Docker image." -ForegroundColor Yellow
+                }
+            }
+            else {
+                Write-Host "  Kept Docker image." -ForegroundColor DarkGray
             }
         }
     }
@@ -169,7 +195,7 @@ if ($Cleanup) {
 
     $EscapedModel = [regex]::Escape($Model)
     if ($CacheOutput -and $CacheOutput -match $EscapedModel) {
-        $RemoveModel = Read-Host "Remove cached model '$Model' from disk? (Y/N)"
+        $RemoveModel = if ($Force) { 'Y' } else { Read-Host "Remove cached model '$Model' from disk? (Y/N)" }
         if ($RemoveModel -eq 'Y' -or $RemoveModel -eq 'y') {
             try {
                 Write-Verbose "Removing model '$Model' from cache..."
@@ -200,7 +226,7 @@ if ($Cleanup) {
     # Uninstall Foundry Local
     $FoundryCmd = Get-Command foundry -ErrorAction SilentlyContinue
     if ($FoundryCmd) {
-        $RemoveFoundry = Read-Host "Uninstall Foundry Local? (Y/N)"
+        $RemoveFoundry = if ($Force) { 'Y' } else { Read-Host "Uninstall Foundry Local? (Y/N)" }
         if ($RemoveFoundry -eq 'Y' -or $RemoveFoundry -eq 'y') {
             Write-Verbose "Detecting operating system for uninstall..."
             if ($IsWindows) {
@@ -239,7 +265,7 @@ if ($Cleanup) {
     # Uninstall Docker Desktop
     $DockerCmd = Get-Command docker -ErrorAction SilentlyContinue
     if ($DockerCmd) {
-        $RemoveDocker = Read-Host "Uninstall Docker Desktop? (Y/N)"
+        $RemoveDocker = if ($Force) { 'Y' } else { Read-Host "Uninstall Docker Desktop? (Y/N)" }
         if ($RemoveDocker -eq 'Y' -or $RemoveDocker -eq 'y') {
             Write-Verbose "Detecting operating system for Docker uninstall..."
             if ($IsWindows) {
@@ -595,7 +621,7 @@ finally {
     Remove-Item $CacheTempOut, $CacheTempErr -ErrorAction SilentlyContinue
 }
 
-if ($CacheOutput | Select-String -SimpleMatch -Pattern $Model -Quiet) {
+if ($CacheOutput -and ($CacheOutput | Select-String -SimpleMatch -Pattern $Model -Quiet)) {
     Write-Verbose "Model '$Model' was found in the local cache."
     Write-Host "Model '$Model' is already downloaded." -ForegroundColor Green
 }
@@ -640,6 +666,7 @@ Write-Host "Getting Foundry Local endpoint..." -ForegroundColor Cyan
 try {
     Write-Verbose "Querying Foundry Local service status..."
     $ServiceOutput = foundry service status 2>&1 | Out-String
+    if ($LASTEXITCODE -ne 0) { throw "foundry service status exited with code $LASTEXITCODE" }
     Write-Verbose "Service status output: $ServiceOutput"
 
     # Extract the endpoint URL exactly as reported by the service so the scheme and host are preserved.

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -238,14 +238,16 @@ if (-not $FoundryInstalled) {
 Write-Host "Starting Foundry Local service..." -ForegroundColor Cyan
 try {
     Write-Verbose "Restarting Foundry Local service to ensure a clean state..."
-    foundry service start 2>$null
+    $null = foundry service start 2>&1 | Out-String
     Write-Verbose "Foundry Local service started."
+    Write-Host "Foundry Local service is running." -ForegroundColor Green
 }
 catch {
     Write-Verbose "Service start attempt failed, trying restart: $_"
     try {
-        foundry service restart
+        $null = foundry service restart 2>&1 | Out-String
         Write-Verbose "Foundry Local service restarted successfully."
+        Write-Host "Foundry Local service is running." -ForegroundColor Green
     }
     catch {
         Write-Verbose "Service restart also failed: $_"
@@ -253,11 +255,31 @@ catch {
     }
 }
 
-Write-Host "Downloading and loading model '$Model'..." -ForegroundColor Cyan
-Write-Host "  (This may take a while on first run as the model is downloaded)" -ForegroundColor DarkGray
+# Check if the model is already cached locally
+$CacheOutput = foundry cache list 2>&1 | Out-String
+if ($CacheOutput -match $Model) {
+    Write-Host "Model '$Model' is already downloaded." -ForegroundColor Green
+}
+else {
+    Write-Host "Downloading model '$Model'..." -ForegroundColor Cyan
+    Write-Host "  (This may take several minutes on first run depending on your connection)" -ForegroundColor DarkGray
+    Write-Host "  Tip: Run 'foundry cache list' in another terminal to check download status." -ForegroundColor DarkGray
+    try {
+        Write-Verbose "Running 'foundry model download $Model'..."
+        foundry model download $Model
+        Write-Verbose "Model '$Model' downloaded successfully."
+        Write-Host "Model '$Model' downloaded." -ForegroundColor Green
+    }
+    catch {
+        Write-Verbose "Model download failed: $_"
+        Write-Error "Failed to download model '$Model'. Run 'foundry model list' to see available models."
+        exit 1
+    }
+}
+
+Write-Host "Loading model '$Model' into Foundry Local service..." -ForegroundColor Cyan
 try {
     Write-Verbose "Running 'foundry model load $Model'..."
-    foundry model download $Model
     foundry model load $Model
     Write-Verbose "Model '$Model' loaded successfully."
     Write-Host "Model '$Model' is ready." -ForegroundColor Green

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -29,6 +29,11 @@
     If specified, only sets up Foundry Local without launching Open WebUI.
     Useful if you only want the Foundry Local service running.
 
+.PARAMETER Cleanup
+    If specified, tears down the demo environment: stops and removes the
+    Open WebUI Docker container and volume, and stops the Foundry Local service.
+    Optionally removes the cached model from disk.
+
 .LINK
     https://learn.microsoft.com/en-us/azure/foundry-local/what-is-foundry-local
     https://github.com/microsoft/Foundry-Local
@@ -44,7 +49,10 @@ Param(
     [int]$OpenWebUIPort = 3000,
 
     [Parameter(HelpMessage = "Skip Open WebUI setup and only start Foundry Local")]
-    [switch]$SkipOpenWebUI
+    [switch]$SkipOpenWebUI,
+
+    [Parameter(HelpMessage = "Tear down the demo environment (remove containers, stop services)")]
+    [switch]$Cleanup
 )
 
 #region Variables
@@ -59,6 +67,88 @@ $OpenWebUIImage = "ghcr.io/open-webui/open-webui:main"
 ########################################################################
 
 $ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
+
+########################################################################
+#                         Cleanup mode                                 #
+########################################################################
+
+if ($Cleanup) {
+    Write-Host "Cleaning up Foundry Local demo environment..." -ForegroundColor Cyan
+
+    # Stop and remove Open WebUI container
+    $ExistingContainer = docker ps -a --filter "name=$ContainerName" --format "{{.ID}}" 2>$null
+    if ($ExistingContainer) {
+        try {
+            Write-Verbose "Stopping and removing Open WebUI container '$ContainerName'..."
+            docker rm -f $ContainerName | Out-Null
+            Write-Host "  Removed Docker container '$ContainerName'." -ForegroundColor Green
+        }
+        catch {
+            Write-Verbose "Failed to remove container: $_"
+            Write-Host "  Could not remove container '$ContainerName'." -ForegroundColor Yellow
+        }
+    }
+    else {
+        Write-Verbose "No container named '$ContainerName' found."
+        Write-Host "  No Open WebUI container found (already removed)." -ForegroundColor DarkGray
+    }
+
+    # Remove Open WebUI Docker volume
+    $ExistingVolume = docker volume ls --filter "name=open-webui-foundry" --format "{{.Name}}" 2>$null
+    if ($ExistingVolume) {
+        $RemoveVolume = Read-Host "Remove Open WebUI data volume (deletes chat history)? (Y/N)"
+        if ($RemoveVolume -eq 'Y' -or $RemoveVolume -eq 'y') {
+            try {
+                Write-Verbose "Removing Docker volume 'open-webui-foundry'..."
+                docker volume rm open-webui-foundry | Out-Null
+                Write-Host "  Removed Docker volume 'open-webui-foundry'." -ForegroundColor Green
+            }
+            catch {
+                Write-Verbose "Failed to remove volume: $_"
+                Write-Host "  Could not remove volume. It may still be in use." -ForegroundColor Yellow
+            }
+        }
+        else {
+            Write-Host "  Kept Docker volume (chat history preserved)." -ForegroundColor DarkGray
+        }
+    }
+
+    # Stop Foundry Local service
+    try {
+        Write-Verbose "Stopping Foundry Local service..."
+        foundry service stop 2>$null
+        Write-Host "  Stopped Foundry Local service." -ForegroundColor Green
+    }
+    catch {
+        Write-Verbose "Foundry service stop failed (may not be running): $_"
+        Write-Host "  Foundry Local service was not running." -ForegroundColor DarkGray
+    }
+
+    # Offer to remove cached model
+    $CacheOutput = foundry cache list 2>&1 | Out-String
+    if ($CacheOutput -match $Model) {
+        $RemoveModel = Read-Host "Remove cached model '$Model' from disk? (Y/N)"
+        if ($RemoveModel -eq 'Y' -or $RemoveModel -eq 'y') {
+            try {
+                Write-Verbose "Removing model '$Model' from cache..."
+                foundry cache rm $Model
+                Write-Host "  Removed model '$Model' from cache." -ForegroundColor Green
+            }
+            catch {
+                Write-Verbose "Failed to remove model from cache: $_"
+                Write-Host "  Could not remove model from cache." -ForegroundColor Yellow
+            }
+        }
+        else {
+            Write-Host "  Kept model '$Model' in cache." -ForegroundColor DarkGray
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Cleanup complete." -ForegroundColor Green
+    Write-Host "Elapsed time: $($ElapsedTime.Elapsed.ToString('hh\:mm\:ss'))" -ForegroundColor DarkGray
+    exit 0
+}
 
 ########################################################################
 #                         Part 1 - Prerequisites                       #


### PR DESCRIPTION
## Summary

Adds a new `FoundryLocal/` demo folder with a cross-platform PowerShell deployment script that sets up **Microsoft Foundry Local** with an **Open WebUI** browser-based chat interface.

## What's included

- **`deploy.ps1`** — One-script deployment for Windows and macOS:
  - Installs Foundry Local (via winget/brew) if not present
  - Installs and launches Docker Desktop if not present
  - Downloads and loads an AI model (default: `qwen2.5-0.5b`, the smallest available)
  - Spins up Open WebUI in Docker, connected to the Foundry Local API
  - Opens the browser to the chat interface
  - `-Cleanup` switch for full teardown (container, volume, model, Foundry Local uninstall)
  - `-SkipOpenWebUI` switch for Foundry Local only (no Docker needed)

- **`README.md`** — Documentation covering prerequisites, quick start, model selection, parameters, troubleshooting, and architecture

## Parameters

| Parameter | Default | Description |
|-----------|---------|-------------|
| `-Model` | `qwen2.5-0.5b` | Model alias to load |
| `-OpenWebUIPort` | `3000` | Local port for the web UI |
| `-SkipOpenWebUI` | — | Skip Docker/Open WebUI setup |
| `-Cleanup` | — | Tear down the demo environment |
| `-Verbose` | — | Detailed progress output |

## Usage

```powershell
# Deploy with defaults
.\deploy.ps1 -Verbose

# Use a different model
.\deploy.ps1 -Model "phi-4-mini" -Verbose

# Clean up everything
.\deploy.ps1 -Cleanup -Verbose
```