### PR TITLE
docs: convert copilot-instructions.md to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 Use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages and PR titles (e.g. `feat:`, `fix:`, `docs:`, `chore:`).
 
+Prefer atomic commits: one logical change per commit. When addressing PR review comments, each comment should be resolved in its own commit.
+
 This is a demo repository. Demo-oriented simplifications are acceptable only when they do not weaken safety or security. Always use safe defaults: never include secrets or PII, never disable or bypass authentication, authorization, validation, or encryption, and never suggest insecure configurations. Limit demo shortcuts to non-safety-critical simplifications (for example, simplified logic or clearly marked hardcoded sample values). When such a shortcut is taken, add a comment noting the shortcut and warn the user that it is not suitable for production use.
 
 # PowerShell Coding Conventions


### PR DESCRIPTION
Move `.github/copilot-instructions.md` to `AGENTS.md` at repo root — the cross-tool standard recognized by GitHub Copilot, OpenAI Codex, Gemini CLI, Cursor, and others.

Also adds an atomic commits guideline for PR review workflows:
> Prefer atomic commits: one logical change per commit. When addressing PR review comments, each comment should be resolved in its own commit.