### PR TITLE
feat: add virtualization check before Docker/OpenWebUI setup

### DIFF
--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -327,6 +327,58 @@ if ($IsWindows) {
 }
 Write-Verbose "Running on $Platform."
 
+# Check hardware virtualization support (required for Docker / Open WebUI)
+if (-not $SkipOpenWebUI) {
+    Write-Verbose "Checking hardware virtualization support..."
+    $VirtualizationSupported = $true
+
+    if ($IsWindows) {
+        try {
+            $Processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop
+            if (-not $Processor.VirtualizationFirmwareEnabled) {
+                $VirtualizationSupported = $false
+                Write-Verbose "CPU virtualization is not enabled in BIOS/UEFI."
+            }
+            else {
+                Write-Verbose "CPU virtualization is enabled."
+            }
+        }
+        catch {
+            Write-Verbose "Could not determine virtualization status: $_"
+        }
+    }
+    elseif ($IsMacOS) {
+        try {
+            $SysctlOutput = sysctl -n kern.hv_support 2>$null
+            if ($SysctlOutput -ne "1") {
+                $VirtualizationSupported = $false
+                Write-Verbose "Hypervisor support is not available on this Mac."
+            }
+            else {
+                Write-Verbose "Hypervisor support is available."
+            }
+        }
+        catch {
+            Write-Verbose "Could not determine virtualization status: $_"
+        }
+    }
+
+    if (-not $VirtualizationSupported) {
+        Write-Host "Hardware virtualization is not enabled on this system." -ForegroundColor Yellow
+        Write-Host "  Docker (required for Open WebUI) needs virtualization support." -ForegroundColor Yellow
+        Write-Host "  You can enable it in your BIOS/UEFI settings, or continue without Open WebUI." -ForegroundColor DarkGray
+        $ContinueWithout = Read-Host "Continue without Open WebUI? (Y/N)"
+        if ($ContinueWithout -eq 'Y' -or $ContinueWithout -eq 'y') {
+            Write-Verbose "User chose to continue without Open WebUI."
+            $SkipOpenWebUI = [switch]::new($true)
+        }
+        else {
+            Write-Host "Enable virtualization in BIOS/UEFI and re-run this script." -ForegroundColor DarkGray
+            exit 1
+        }
+    }
+}
+
 # Check Docker (required for Open WebUI)
 if (-not $SkipOpenWebUI) {
     Write-Verbose "Checking for Docker..."

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -335,7 +335,13 @@ if (-not $SkipOpenWebUI) {
     if ($IsWindows) {
         try {
             $Processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop
-            if (-not $Processor.VirtualizationFirmwareEnabled) {
+            $VirtualizationFirmwareEnabledValues = @($Processor | Select-Object -ExpandProperty VirtualizationFirmwareEnabled -ErrorAction SilentlyContinue)
+            $ReportedVirtualizationFirmwareEnabledValues = @($VirtualizationFirmwareEnabledValues | Where-Object { $null -ne $_ })
+
+            if ($ReportedVirtualizationFirmwareEnabledValues.Count -eq 0) {
+                Write-Verbose "CPU virtualization status could not be determined because VirtualizationFirmwareEnabled was not reported."
+            }
+            elseif ($ReportedVirtualizationFirmwareEnabledValues -contains $false) {
                 $VirtualizationSupported = $false
                 Write-Verbose "CPU virtualization is not enabled in BIOS/UEFI."
             }

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -354,18 +354,19 @@ if (-not $SkipOpenWebUI) {
         }
     }
     elseif ($IsMacOS) {
-        try {
-            $SysctlOutput = sysctl -n kern.hv_support 2>$null
-            if ($SysctlOutput -ne "1") {
-                $VirtualizationSupported = $false
-                Write-Verbose "Hypervisor support is not available on this Mac."
-            }
-            else {
-                Write-Verbose "Hypervisor support is available."
-            }
+        $SysctlOutput = sysctl -n kern.hv_support 2>$null
+        $SysctlExitCode = $LASTEXITCODE
+        $SysctlOutput = "$SysctlOutput".Trim()
+
+        if ($SysctlExitCode -eq 0 -and $SysctlOutput -eq "1") {
+            Write-Verbose "Hypervisor support is available."
         }
-        catch {
-            Write-Verbose "Could not determine virtualization status: $_"
+        elseif ($SysctlExitCode -eq 0 -and $SysctlOutput -eq "0") {
+            $VirtualizationSupported = $false
+            Write-Verbose "Hypervisor support is not available on this Mac."
+        }
+        else {
+            Write-Verbose "Could not determine virtualization status."
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a hardware virtualization check to `FoundryLocal/deploy.ps1` before attempting Docker setup for Open WebUI.

## Problem

The script would proceed to install/start Docker without verifying that the system supports virtualization, leading to confusing failures on machines where virtualization is disabled in BIOS/UEFI.

## Changes

- **Windows**: Checks `Win32_Processor.VirtualizationFirmwareEnabled` via CIM
- **macOS**: Checks `kern.hv_support` via `sysctl`
- If virtualization is not enabled, prompts the user to either continue without Open WebUI or exit to enable it in BIOS/UEFI
- Gracefully handles cases where the virtualization status cannot be determined