### PR TITLE
fix: Docker Desktop install and virtualization detection on Windows

### DIFF
--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -446,6 +446,11 @@ if (-not $SkipOpenWebUI) {
                         Write-Error "winget is required to install Docker Desktop but was not found. Install winget from https://learn.microsoft.com/en-us/windows/package-manager/winget/ and re-run this script."
                         exit 1
                     }
+                    $CurrentPrincipal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+                    if (-not $CurrentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+                        Write-Error "Installing Docker Desktop requires administrator privileges. Please re-run this script from an elevated (Run as Administrator) PowerShell prompt."
+                        exit 1
+                    }
                     try {
                         Write-Verbose "Installing Docker Desktop via winget..."
                         winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -66,7 +66,7 @@ Param(
 
 $ContainerName = "open-webui-foundry"
 $VolumeName = "open-webui-foundry"
-$OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.8.6"
+$OpenWebUIImage = "ghcr.io/open-webui/open-webui:v0.9.1"
 
 #endregion Variables
 

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -349,15 +349,15 @@ if (-not $SkipOpenWebUI) {
                 Write-Verbose "CPU virtualization is enabled in BIOS/UEFI."
             }
 
-            # VT-x in BIOS is necessary but not sufficient — Docker Desktop also requires
-            # Hyper-V or WSL2 to be enabled as a Windows feature. HypervisorPresent reflects
-            # whether a hypervisor is actually running, catching cases where VT-x is on but
-            # neither Hyper-V nor WSL2 has been enabled.
+            # VT-x in BIOS is necessary but not sufficient for Docker Desktop on Windows.
+            # HypervisorPresent only indicates whether Windows is currently running with a
+            # hypervisor active; it does not by itself confirm that specific optional
+            # features such as Hyper-V or WSL2 are enabled.
             if ($VirtualizationSupported) {
                 $ComputerSystem = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
                 if (-not $ComputerSystem.HypervisorPresent) {
                     $VirtualizationSupported = $false
-                    Write-Verbose "Hypervisor is not running. Hyper-V or WSL2 must be enabled for Docker Desktop."
+                    Write-Verbose "Hypervisor is not running. Required Windows virtualization features may not be enabled or active for Docker Desktop."
                 }
                 else {
                     Write-Verbose "Hypervisor is present and active."
@@ -399,6 +399,12 @@ if (-not $SkipOpenWebUI) {
             $SkipOpenWebUI = [switch]::new($true)
         }
         else {
+            Write-Host "Please enable the required virtualization support" -NoNewline -ForegroundColor Yellow
+            if ($IsWindows) {
+                Write-Host " (including Hyper-V or WSL2, if applicable)" -NoNewline -ForegroundColor Yellow
+            }
+            Write-Host " and then re-run this script." -ForegroundColor Yellow
+            Write-Host "Alternatively, re-run with -SkipOpenWebUI to proceed without the chat interface." -ForegroundColor DarkGray
             exit 1
         }
     }

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -446,16 +446,17 @@ if (-not $SkipOpenWebUI) {
                         Write-Error "winget is required to install Docker Desktop but was not found. Install winget from https://learn.microsoft.com/en-us/windows/package-manager/winget/ and re-run this script."
                         exit 1
                     }
-                    $CurrentPrincipal = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
-                    if (-not $CurrentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
-                        Write-Error "Installing Docker Desktop requires administrator privileges. Please re-run this script from an elevated (Run as Administrator) PowerShell prompt."
-                        exit 1
-                    }
                     try {
-                        Write-Verbose "Installing Docker Desktop via winget..."
-                        winget install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements
+                        Write-Verbose "Installing Docker Desktop via winget (elevated)..."
+                        # Docker Desktop 4.40+ requires winget itself to run as admin — spawning an elevated
+                        # installer subprocess via UAC is no longer sufficient. Start-Process -Verb RunAs
+                        # elevates winget directly and triggers a single UAC prompt if needed.
+                        $WingetPath = (Get-Command winget -ErrorAction Stop).Source
+                        $WingetArgs = "install Docker.DockerDesktop --accept-source-agreements --accept-package-agreements"
+                        $Process = Start-Process -FilePath $WingetPath -ArgumentList $WingetArgs -Verb RunAs -Wait -PassThru -ErrorAction Stop
+                        $ExitCode = $Process.ExitCode
                         # winget returns -1978335189 when the package is already installed with no upgrade available
-                        if ($LASTEXITCODE -ne 0 -and $LASTEXITCODE -ne -1978335189) { throw "winget install exited with code $LASTEXITCODE" }
+                        if ($ExitCode -ne 0 -and $ExitCode -ne -1978335189) { throw "winget install exited with code $ExitCode" }
                         Write-Verbose "Docker Desktop installed via winget."
                     }
                     catch {

--- a/FoundryLocal/deploy.ps1
+++ b/FoundryLocal/deploy.ps1
@@ -346,7 +346,22 @@ if (-not $SkipOpenWebUI) {
                 Write-Verbose "CPU virtualization is not enabled in BIOS/UEFI."
             }
             else {
-                Write-Verbose "CPU virtualization is enabled."
+                Write-Verbose "CPU virtualization is enabled in BIOS/UEFI."
+            }
+
+            # VT-x in BIOS is necessary but not sufficient — Docker Desktop also requires
+            # Hyper-V or WSL2 to be enabled as a Windows feature. HypervisorPresent reflects
+            # whether a hypervisor is actually running, catching cases where VT-x is on but
+            # neither Hyper-V nor WSL2 has been enabled.
+            if ($VirtualizationSupported) {
+                $ComputerSystem = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+                if (-not $ComputerSystem.HypervisorPresent) {
+                    $VirtualizationSupported = $false
+                    Write-Verbose "Hypervisor is not running. Hyper-V or WSL2 must be enabled for Docker Desktop."
+                }
+                else {
+                    Write-Verbose "Hypervisor is present and active."
+                }
             }
         }
         catch {
@@ -371,16 +386,19 @@ if (-not $SkipOpenWebUI) {
     }
 
     if (-not $VirtualizationSupported) {
-        Write-Host "Hardware virtualization is not enabled on this system." -ForegroundColor Yellow
+        Write-Host "Hardware virtualization is not available on this system." -ForegroundColor Yellow
         Write-Host "  Docker (required for Open WebUI) needs virtualization support." -ForegroundColor Yellow
-        Write-Host "  You can enable it in your BIOS/UEFI settings, or continue without Open WebUI." -ForegroundColor DarkGray
+        if ($IsWindows) {
+            Write-Host "  Ensure VT-x/AMD-V is enabled in BIOS/UEFI and that Hyper-V or WSL2 is" -ForegroundColor DarkGray
+            Write-Host "  enabled as a Windows feature (Settings > Optional features > More Windows features)." -ForegroundColor DarkGray
+        }
+        Write-Host "  You can also continue without Open WebUI using -SkipOpenWebUI." -ForegroundColor DarkGray
         $ContinueWithout = Read-Host "Continue without Open WebUI? (Y/N)"
         if ($ContinueWithout -eq 'Y' -or $ContinueWithout -eq 'y') {
             Write-Verbose "User chose to continue without Open WebUI."
             $SkipOpenWebUI = [switch]::new($true)
         }
         else {
-            Write-Host "Enable virtualization in BIOS/UEFI and re-run this script." -ForegroundColor DarkGray
             exit 1
         }
     }


### PR DESCRIPTION
## Summary

Fixes two issues encountered when running `deploy.ps1` on a fresh Windows 11 machine.

### Fix 1: Elevate winget for Docker Desktop install

Docker Desktop 4.40+ requires the calling process (`winget`) to be elevated, not just the installer subprocess. Previously, the script called `winget` directly which would spawn the Docker installer and prompt for UAC — but Docker would reject the installation because its parent process wasn't elevated.

Changed to `Start-Process winget -Verb RunAs` so winget itself runs elevated (one UAC prompt), satisfying Docker's requirement.

### Fix 2: Check Hyper-V/WSL2 in addition to BIOS VT-x

The virtualization check only queried `Win32_Processor.VirtualizationFirmwareEnabled` (VT-x in BIOS). Docker Desktop also requires Hyper-V or WSL2 to be enabled as a Windows feature. Added a `Win32_ComputerSystem.HypervisorPresent` check so the script fails early with an actionable message instead of installing Docker and waiting 5 minutes for an engine that will never start.

### Fix 3: Bump Open WebUI to v0.9.1