### PR TITLE
fix: ignore crossplane generated manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .terraform*
 terraform.tfvars
 terraform.tfstate*
+
+# Crossplane generated manifests can contain environment-specific identifiers.
+Crossplane/.generated/


### PR DESCRIPTION
## Summary

Adds `Crossplane/.generated/` to `.gitignore` so generated Crossplane manifests with environment-specific identifiers stay local.

## Why

`Deploy.ps1` writes substituted manifests into `.generated/`. Those values are not secrets, but they can include tenant IDs, subscription IDs, client IDs, and resource names that should not be accidentally committed.

## Validation

- Reviewed the local diff for `.gitignore`
- No automated tests run; this is a gitignore-only change
