### PR TITLE
feat: add cp storage demo

### DIFF
--- a/Crossplane/demo-storage.yaml
+++ b/Crossplane/demo-storage.yaml
@@ -1,0 +1,23 @@
+apiVersion: platform.example.org/v1alpha1
+kind: StorageAccount
+metadata:
+  name: zone-storage-account
+spec:
+  parameters:
+    name: democrossplane123zone
+    geoRedundant: false
+    tags:
+      environment: demo
+      owner: platform
+---
+apiVersion: platform.example.org/v1alpha1
+kind: StorageAccount
+metadata:
+  name: geo-storage-account
+spec:
+  parameters:
+    name: democrossplane123geo
+    geoRedundant: true
+    tags:
+      environment: demo
+      owner: platform

--- a/Crossplane/kubernetes/platform/storage-account.yaml
+++ b/Crossplane/kubernetes/platform/storage-account.yaml
@@ -1,0 +1,120 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-patch-and-transform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.8.2
+---
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: storageaccounts.platform.example.org
+spec:
+  group: platform.example.org
+  names:
+    kind: StorageAccount
+    plural: storageaccounts
+  defaultCompositionRef:
+    name: storageaccounts.azure.storage.platform.example.org
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              parameters:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Storage name.
+                    minLength: 3
+                    maxLength: 24
+                    pattern: '^[a-z0-9]+$'
+                  geoRedundant:
+                    type: boolean
+                    description: Whether the backing implementation should use geo-redundant replication.
+                  tags:
+                    type: object
+                    description: Arbitrary tags to apply to the backing storage account.
+                    additionalProperties:
+                      type: string
+                required:
+                - name
+                - geoRedundant
+            required:
+            - parameters
+          status:
+            type: object
+            properties:
+              accountName:
+                type: string
+    additionalPrinterColumns:
+    - name: Name
+      type: string
+      jsonPath: .spec.parameters.name
+    - name: Geo
+      type: string
+      jsonPath: .spec.parameters.geoRedundant
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: storageaccounts.azure.storage.platform.example.org
+spec:
+  compositeTypeRef:
+    apiVersion: platform.example.org/v1alpha1
+    kind: StorageAccount
+  mode: Pipeline
+  pipeline:
+  - step: patch-and-transform
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+      - name: storage-account
+        base:
+          apiVersion: storage.azure.m.upbound.io/v1beta1
+          kind: Account
+          spec:
+            forProvider:
+              accountKind: StorageV2
+              accountTier: Standard
+              accountReplicationType: ZRS
+              location: swedencentral
+              resourceGroupName: rg-crossplanedemo
+              tags: {}
+            providerConfigRef:
+              kind: ClusterProviderConfig
+              name: default
+        patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.name
+          toFieldPath: metadata.annotations["crossplane.io/external-name"]
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.tags
+          toFieldPath: spec.forProvider.tags
+          policy:
+            fromFieldPath: Optional
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.parameters.geoRedundant
+          toFieldPath: spec.forProvider.accountReplicationType
+          transforms:
+          - type: convert
+            convert:
+              toType: string
+          - type: map
+            map:
+              "true": GRS
+              "false": ZRS
+        - type: ToCompositeFieldPath
+          fromFieldPath: metadata.annotations["crossplane.io/external-name"]
+          toFieldPath: status.accountName
+---

--- a/Crossplane/kubernetes/platform/storage-account.yaml
+++ b/Crossplane/kubernetes/platform/storage-account.yaml
@@ -59,7 +59,7 @@ spec:
       type: string
       jsonPath: .spec.parameters.name
     - name: Geo
-      type: string
+      type: boolean
       jsonPath: .spec.parameters.geoRedundant
 ---
 apiVersion: apiextensions.crossplane.io/v1

--- a/Crossplane/kubernetes/providers/provider-azure-storage.yaml
+++ b/Crossplane/kubernetes/providers/provider-azure-storage.yaml
@@ -5,6 +5,6 @@ kind: Provider
 metadata:
   name: provider-azure-storage
 spec:
-  package: xpkg.upbound.io/upbound/provider-azure-storage:v1.11.0
+  package: xpkg.upbound.io/upbound/provider-azure-storage:v2.6.0
   runtimeConfigRef:
     name: provider-azure

--- a/Crossplane/kubernetes/providers/provider-family-azure.yaml
+++ b/Crossplane/kubernetes/providers/provider-family-azure.yaml
@@ -5,6 +5,6 @@ kind: Provider
 metadata:
   name: provider-family-azure
 spec:
-  package: xpkg.upbound.io/upbound/provider-family-azure:v1.11.0
+  package: xpkg.upbound.io/upbound/provider-family-azure:v2.6.0
   runtimeConfigRef:
     name: provider-azure


### PR DESCRIPTION
* Adds stuff for a demo of storage provisioning via cloud-agnostic api with crossplane