### PR TITLE
fix: unbreak Crossplane on AKS Automatic demo

### DIFF
--- a/Crossplane/Deploy.ps1
+++ b/Crossplane/Deploy.ps1
@@ -193,6 +193,12 @@ if (-not $SkipInfrastructure) {
         throw
     }
 
+    # Save deployment context immediately so -Cleanup can find the new resource
+    # group even if a later step fails before manifest generation
+    if (-not (Test-Path $GeneratedDir)) { New-Item -ItemType Directory -Path $GeneratedDir | Out-Null }
+    @{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
+    Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
+
     try {
         $Context = Get-AzContext -ErrorAction Stop
         if (-not $Context) { throw 'No Azure context found. Run Connect-AzAccount first.' }
@@ -287,8 +293,8 @@ if (Test-Path $GeneratedDir) { Remove-Item $GeneratedDir -Recurse -Force }
 
 Copy-Item -Path (Join-Path $ScriptRoot 'kubernetes') -Destination $GeneratedDir -Recurse
 
-# Save deployment context so -Cleanup can find the correct resource group.
-# Saved here (not in Part 1) because this step recreates the .generated/ folder.
+# Re-save deployment context because recreating .generated/ above wiped it
+# (also covers -SkipInfrastructure runs that never hit the Part 1 save)
 @{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
 Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
 

--- a/Crossplane/Deploy.ps1
+++ b/Crossplane/Deploy.ps1
@@ -67,11 +67,46 @@ $RequiredModules = @('Az.Accounts', 'Az.Resources', 'Az.Aks')
 
 $ElapsedTime = [System.Diagnostics.Stopwatch]::StartNew()
 
+function Assert-ExitCode {
+    <#
+    .SYNOPSIS
+        Throws if the last external command returned a non-zero exit code.
+    .PARAMETER Message
+        Error message to include in the thrown exception.
+    .EXAMPLE
+        Assert-ExitCode 'kubectl apply failed.'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, HelpMessage = 'Error message to throw on failure.')]
+        [string]$Message
+    )
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "$Message (exit code: $LASTEXITCODE)"
+    }
+}
+
 ########################################################################
 #                          Preparations                                #
 ########################################################################
 
 #region Preparations
+
+Write-Verbose 'Checking required external tools are on PATH.'
+foreach ($Tool in @('az', 'kubectl', 'helm', 'kubelogin')) {
+    if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) {
+        throw "Required tool '$Tool' not found on PATH. Install it before running this script."
+    }
+    Write-Verbose "Found '$Tool'."
+}
+
+# kubelogin runs in azurecli mode, which authenticates kubectl with the Azure CLI token —
+# verify the az CLI session up front instead of failing halfway through the deployment
+Write-Verbose 'Verifying Azure CLI login (used by kubelogin for kubectl auth).'
+az account show --output none
+Assert-ExitCode 'No Azure CLI session found. Run ''az login'' first — kubelogin uses the az CLI token to authenticate kubectl.'
+Write-Verbose 'Azure CLI session found.'
 
 Write-Verbose 'Ensuring required Az modules are installed.'
 
@@ -133,26 +168,6 @@ if ($Cleanup) {
 
 #endregion Cleanup
 
-function Assert-ExitCode {
-    <#
-    .SYNOPSIS
-        Throws if the last external command returned a non-zero exit code.
-    .PARAMETER Message
-        Error message to include in the thrown exception.
-    .EXAMPLE
-        Assert-ExitCode 'kubectl apply failed.'
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory, HelpMessage = 'Error message to throw on failure.')]
-        [string]$Message
-    )
-
-    if ($LASTEXITCODE -ne 0) {
-        throw "$Message (exit code: $LASTEXITCODE)"
-    }
-}
-
 ########################################################################
 #               Part 1 - Deploying infrastructure                     #
 ########################################################################
@@ -174,11 +189,6 @@ if (-not $SkipInfrastructure) {
         throw
     }
 
-    # Save deployment context so cleanup can find the correct resource group
-    if (-not (Test-Path $GeneratedDir)) { New-Item -Path $GeneratedDir -ItemType Directory -Force | Out-Null }
-    @{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
-    Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
-
     try {
         $Context = Get-AzContext -ErrorAction Stop
         if (-not $Context) { throw 'No Azure context found. Run Connect-AzAccount first.' }
@@ -198,24 +208,17 @@ if (-not $SkipInfrastructure) {
         throw
     }
 
-    Write-Verbose 'Starting Bicep deployment...'
-    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Bicep deployment in progress — this may take a while...' -PercentComplete 25 -ErrorAction SilentlyContinue
+    Write-Verbose 'Starting Bicep deployment (typically takes 5-10 minutes)...'
+    Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status 'Bicep deployment in progress — this may take a while...' -PercentComplete 50 -ErrorAction SilentlyContinue
     try {
-        $DeploymentJob = New-AzResourceGroupDeployment `
+        # Run synchronously so ARM error details surface directly in the terminating error
+        $InfraDeployment = New-AzResourceGroupDeployment `
             -Name 'main' `
             -ResourceGroupName $ResourceGroupName `
             -TemplateFile "$ScriptRoot/infrastructure/main.bicep" `
             -clusterAdminPrincipalId $PrincipalId `
-            -AsJob
-
-        while ($DeploymentJob.State -eq 'Running') {
-            Start-Sleep -Seconds 5
-            $MinutesElapsed = [math]::Round(((Get-Date) - $DeploymentJob.PSBeginTime).TotalMinutes, 1)
-            Write-Progress -Id 1 -ParentId 0 -Activity 'Infrastructure' -Status "Bicep deployment in progress — $MinutesElapsed min elapsed" -PercentComplete 50 -ErrorAction SilentlyContinue
-        }
-
-        $DeploymentJob | Receive-Job -Wait -AutoRemoveJob | Out-Null
-        Write-Verbose 'Bicep deployment complete.'
+            -ErrorAction Stop
+        Write-Verbose "Bicep deployment complete. Provisioning state: $($InfraDeployment.ProvisioningState)."
     }
     catch {
         Write-Verbose "Bicep deployment failed: $($_.Exception.Message)"
@@ -280,6 +283,11 @@ if (Test-Path $GeneratedDir) { Remove-Item $GeneratedDir -Recurse -Force }
 
 Copy-Item -Path (Join-Path $ScriptRoot 'kubernetes') -Destination $GeneratedDir -Recurse
 
+# Save deployment context so -Cleanup can find the correct resource group.
+# Saved here (not in Part 1) because this step recreates the .generated/ folder.
+@{ ResourceGroupName = $ResourceGroupName } | ConvertTo-Json | Set-Content (Join-Path $GeneratedDir 'deployment-context.json')
+Write-Verbose 'Saved deployment context to .generated/deployment-context.json.'
+
 $YamlFiles = Get-ChildItem -Path $GeneratedDir -Recurse -Filter *.yaml
 
 $Progress = 0
@@ -339,15 +347,22 @@ catch {
 Write-Progress -Id 0 -Activity 'Crossplane deployment' -Status 'Part 5 of 6 — Installing Crossplane' -PercentComplete 67 -ErrorAction SilentlyContinue
 Write-Verbose 'Installing Crossplane...'
 
-# Remove ValidatingAdmissionPolicy bindings that conflict with Crossplane.
-# aks-managed-block-nodes-proxy-rbac-binding: blocked Crossplane's null-rules ClusterRoles (Crossplane v1).
-# aks-managed-block-webhook-configs-targeting-protected-resources-binding: blocked Crossplane v2's
-#   crossplane-no-usages ValidatingWebhookConfiguration from targeting TokenReviews/CSRs.
-# Both are deleted best-effort — they may be absent or already protected on newer AKS builds.
-# The webhooks.enabled=false Helm value is the primary workaround for the second binding.
-kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found
-kubectl delete validatingadmissionpolicybinding aks-managed-block-webhook-configs-targeting-protected-resources-binding --ignore-not-found
-# Intentionally not checking exit codes — bindings may be absent or protected
+try {
+    # AKS's aks-managed-block-nodes-proxy-rbac ValidatingAdmissionPolicy has a CEL bug
+    # (Azure/AKS#5640) that rejects Crossplane's aggregated ClusterRoles (null rules).
+    # Delete the binding so the Helm install can create them — AKS recreates the binding
+    # on its next reconciliation, which is fine once the roles exist.
+    # Crossplane's webhook conflict with AKS Automatic is handled separately via
+    # webhooks.enabled=false in crossplane-values.yaml.
+    Write-Verbose 'Removing AKS ValidatingAdmissionPolicy binding that blocks Crossplane ClusterRoles...'
+    kubectl delete validatingadmissionpolicybinding aks-managed-block-nodes-proxy-rbac-binding --ignore-not-found
+    Assert-ExitCode 'Failed to delete ValidatingAdmissionPolicyBinding aks-managed-block-nodes-proxy-rbac-binding.'
+    Write-Verbose 'ValidatingAdmissionPolicy binding removed (or already absent).'
+}
+catch {
+    Write-Verbose "Failed to remove ValidatingAdmissionPolicy binding: $($_.Exception.Message)"
+    throw
+}
 
 try {
     Write-Verbose 'Adding Crossplane Helm repo...'
@@ -366,12 +381,15 @@ catch {
 try {
     Write-Verbose 'Installing Crossplane via Helm...'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Status 'Installing Crossplane chart — waiting for pods...' -PercentComplete 50 -ErrorAction SilentlyContinue
+    # --timeout 15m: on AKS Automatic the first workload triggers node autoprovisioning,
+    # which can exceed helm's default 5m wait
     helm upgrade crossplane crossplane-stable/crossplane `
         --install `
         --namespace crossplane-system `
         --create-namespace `
         --values "$GeneratedDir/crossplane/crossplane-values.yaml" `
-        --wait
+        --wait `
+        --timeout 15m
     Assert-ExitCode 'helm upgrade/install crossplane failed.'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Helm install' -Completed -ErrorAction SilentlyContinue
     Write-Verbose 'Crossplane installed and ready.'
@@ -412,7 +430,7 @@ try {
 
     Write-Verbose 'Waiting for provider-family-azure to become healthy...'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Providers' -Status 'Waiting for provider-family-azure to become healthy...' -PercentComplete 33 -ErrorAction SilentlyContinue
-    kubectl wait --for=condition=Healthy providers.pkg.crossplane.io/provider-family-azure --timeout=300s
+    kubectl wait --for=condition=Healthy providers.pkg.crossplane.io/provider-family-azure --timeout=600s
     Assert-ExitCode 'provider-family-azure did not become healthy within timeout.'
     Write-Verbose 'provider-family-azure is healthy.'
 }
@@ -439,7 +457,7 @@ try {
 
     Write-Verbose 'Waiting for provider-azure-storage to become healthy...'
     Write-Progress -Id 1 -ParentId 0 -Activity 'Providers' -Status 'Waiting for provider-azure-storage to become healthy...' -PercentComplete 66 -ErrorAction SilentlyContinue
-    kubectl wait --for=condition=Healthy providers.pkg.crossplane.io/provider-azure-storage --timeout=300s
+    kubectl wait --for=condition=Healthy providers.pkg.crossplane.io/provider-azure-storage --timeout=600s
     Assert-ExitCode 'provider-azure-storage did not become healthy within timeout.'
     Write-Verbose 'provider-azure-storage is healthy.'
 }

--- a/Crossplane/Deploy.ps1
+++ b/Crossplane/Deploy.ps1
@@ -93,20 +93,24 @@ function Assert-ExitCode {
 
 #region Preparations
 
-Write-Verbose 'Checking required external tools are on PATH.'
-foreach ($Tool in @('az', 'kubectl', 'helm', 'kubelogin')) {
-    if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) {
-        throw "Required tool '$Tool' not found on PATH. Install it before running this script."
+# Cleanup only uses Az PowerShell cmdlets and local file operations —
+# skip the deployment-only tool and Azure CLI session checks in that mode
+if (-not $Cleanup) {
+    Write-Verbose 'Checking required external tools are on PATH.'
+    foreach ($Tool in @('az', 'kubectl', 'helm', 'kubelogin')) {
+        if (-not (Get-Command $Tool -ErrorAction SilentlyContinue)) {
+            throw "Required tool '$Tool' not found on PATH. Install it before running this script."
+        }
+        Write-Verbose "Found '$Tool'."
     }
-    Write-Verbose "Found '$Tool'."
-}
 
-# kubelogin runs in azurecli mode, which authenticates kubectl with the Azure CLI token —
-# verify the az CLI session up front instead of failing halfway through the deployment
-Write-Verbose 'Verifying Azure CLI login (used by kubelogin for kubectl auth).'
-az account show --output none
-Assert-ExitCode 'No Azure CLI session found. Run ''az login'' first — kubelogin uses the az CLI token to authenticate kubectl.'
-Write-Verbose 'Azure CLI session found.'
+    # kubelogin runs in azurecli mode, which authenticates kubectl with the Azure CLI token —
+    # verify the az CLI session up front instead of failing halfway through the deployment
+    Write-Verbose 'Verifying Azure CLI login (used by kubelogin for kubectl auth).'
+    az account show --output none
+    Assert-ExitCode 'No Azure CLI session found. Run ''az login'' first — kubelogin uses the az CLI token to authenticate kubectl.'
+    Write-Verbose 'Azure CLI session found.'
+}
 
 Write-Verbose 'Ensuring required Az modules are installed.'
 

--- a/Crossplane/infrastructure/aks.bicep
+++ b/Crossplane/infrastructure/aks.bicep
@@ -2,7 +2,11 @@ param clusterName string
 param location string
 param clusterAdminPrincipalId string
 
-resource aks 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
+// AKS Automatic: system node pools are managed by Azure and must NOT be declared here —
+// an explicit agentPoolProfiles system pool makes cluster creation fail.
+// OIDC issuer and workload identity are on by default for Automatic, but are kept explicit
+// because the identity module depends on the issuer URL output.
+resource aks 'Microsoft.ContainerService/managedClusters@2026-02-01' = {
   name: clusterName
   location: location
   sku: {
@@ -12,15 +16,6 @@ resource aks 'Microsoft.ContainerService/managedClusters@2024-10-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    dnsPrefix: clusterName
-    agentPoolProfiles: [
-      {
-        name: 'systempool'
-        mode: 'System'
-        count: 3
-        vmSize: 'Standard_D4ds_v5'
-      }
-    ]
     oidcIssuerProfile: {
       enabled: true
     }

--- a/Crossplane/infrastructure/main.bicep
+++ b/Crossplane/infrastructure/main.bicep
@@ -1,8 +1,8 @@
 @description('Project name used for resource naming')
 param projectName string = 'crossplane'
 
-@description('Azure region for all resources')
-param location string = 'swedencentral'
+@description('Azure region for all resources — defaults to the resource group location')
+param location string = resourceGroup().location
 
 @description('Principal ID of the user to assign AKS RBAC Cluster Admin')
 param clusterAdminPrincipalId string

--- a/Crossplane/readme.md
+++ b/Crossplane/readme.md
@@ -45,6 +45,7 @@ Crossplane/
 
 - Azure PowerShell (`Az.Accounts`, `Az.Resources`, `Az.Aks` modules) with an active login (`Connect-AzAccount`)
   - The deploy script will auto-install missing modules into the CurrentUser scope
+- Azure CLI with an active login (`az login`) — `kubelogin` uses the az CLI token to authenticate `kubectl`
 - `kubectl` and `kubelogin`
 - Helm 3
 


### PR DESCRIPTION
## Why

The Crossplane demo broke again — this time because AKS Automatic moved to Microsoft-managed system node pools, and the deploy script was hiding the actual ARM errors, making it needlessly painful to troubleshoot.

## What broke

- **`aks.bicep` declared an explicit system node pool.** AKS Automatic now provisions managed system node pools by default; an explicit `agentPoolProfiles` system pool makes cluster creation fail. Aligned with the current official quickstart shape (API `2026-02-01`, no agent pools, no `dnsPrefix`).
- **`Deploy.ps1` swallowed errors.** The Bicep deployment ran via `-AsJob` with `Receive-Job | Out-Null`, hiding ARM error details. The ValidatingAdmissionPolicy binding deletes intentionally ignored exit codes.

## Changes

**Bicep**
- Minimal AKS Automatic cluster: managed system node pools, API `2026-02-01` (local Bicep 0.42 lacks types for it — benign BCP081 warning, ARM validates server-side)
- `location` defaults to `resourceGroup().location`, so `-Location` actually takes effect

**Deploy.ps1 — no more hidden errors**
- Bicep deployment runs synchronously; ARM errors surface directly in the thrown error
- VAP binding delete checks its exit code; dropped the redundant second binding delete (`webhooks.enabled=false` in the Helm values already covers it)
- Fail-fast prereq checks: `az`/`kubectl`/`helm`/`kubelogin` on PATH and an active `az login` session (kubelogin needs it)
- Fixed `-Cleanup`: `deployment-context.json` was written in Part 1 and then wiped when Part 3 recreated `.generated/`
- `helm --wait --timeout 15m` and provider waits at 600s to allow for node autoprovisioning on Automatic

**Docs**
- Added the `az login` prerequisite to the readme

## Untouched (per request)

Everything under `kubernetes/` — Crossplane values, service account, DeploymentRuntimeConfig, providers, provider config. Helm still installs the latest stable Crossplane (chart unpinned), and the managed identity + federated credential + Contributor role assignment flow is unchanged.

## Validation

- `bicep build` clean (except the expected BCP081 types warning)
- `Deploy.ps1` parses clean